### PR TITLE
Loading fabric mods from different directories

### DIFF
--- a/src/main/java/dev/su5ed/sinytra/connector/ConnectorUtil.java
+++ b/src/main/java/dev/su5ed/sinytra/connector/ConnectorUtil.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -30,8 +29,6 @@ public final class ConnectorUtil {
     public static final String CONNECTOR_MARKER = "connector_transformed";
     public static final String FORGE_MODID = "forge";
     public static final long ZIP_TIME = 318211200000L;
-    // Not final arraylist which allows other mods to add more fabric mods from different directories than default mods folder
-    public static List<Path> FABRIC_MODS_FOLDERS = new ArrayList<>(List.of(FMLPaths.MODSDIR.get()));
     public static final Path CONNECTOR_FOLDER = FMLPaths.MODSDIR.get().resolve(".connector");
     public static final String CONNECTOR_MODID = "connectormod";
     public static final String CONNECTOR_ISSUE_TRACKER_URL = "https://github.com/Sinytra/Connector/issues";

--- a/src/main/java/dev/su5ed/sinytra/connector/ConnectorUtil.java
+++ b/src/main/java/dev/su5ed/sinytra/connector/ConnectorUtil.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -29,6 +30,8 @@ public final class ConnectorUtil {
     public static final String CONNECTOR_MARKER = "connector_transformed";
     public static final String FORGE_MODID = "forge";
     public static final long ZIP_TIME = 318211200000L;
+    // Not final arraylist which allows other mods to add more fabric mods from different directories than default mods folder
+    public static List<Path> FABRIC_MODS_FOLDERS = new ArrayList<>(List.of(FMLPaths.MODSDIR.get()));
     public static final Path CONNECTOR_FOLDER = FMLPaths.MODSDIR.get().resolve(".connector");
     public static final String CONNECTOR_MODID = "connectormod";
     public static final String CONNECTOR_ISSUE_TRACKER_URL = "https://github.com/Sinytra/Connector/issues";

--- a/src/main/java/dev/su5ed/sinytra/connector/locator/ConnectorLocator.java
+++ b/src/main/java/dev/su5ed/sinytra/connector/locator/ConnectorLocator.java
@@ -12,6 +12,7 @@ import net.fabricmc.loader.impl.metadata.NestedJarEntry;
 import net.minecraftforge.fml.loading.ClasspathLocatorUtils;
 import net.minecraftforge.fml.loading.EarlyLoadingException;
 import net.minecraftforge.fml.loading.FMLEnvironment;
+import net.minecraftforge.fml.loading.FMLPaths;
 import net.minecraftforge.fml.loading.LogMarkers;
 import net.minecraftforge.fml.loading.ModDirTransformerDiscoverer;
 import net.minecraftforge.fml.loading.StringUtils;
@@ -85,10 +86,7 @@ public class ConnectorLocator extends AbstractJarFileModProvider implements IDep
     }
 
     private List<IModFile> locateFabricMods(Iterable<IModFile> loadedMods) {
-        StringBuilder sb = new StringBuilder();
-        ConnectorUtil.FABRIC_MODS_FOLDERS.forEach(path -> sb.append("'").append(path).append("' "));
-        String modsFolders = sb.toString().trim();
-        LOGGER.debug(SCAN, "Scanning mods dirs {} for mods", modsFolders);
+        LOGGER.debug(SCAN, "Scanning mods dir {} for mods", FMLPaths.MODSDIR.get());
         Path tempDir = ConnectorUtil.CONNECTOR_FOLDER.resolve("temp");
         // Get all existing mod ids
         Collection<SimpleModInfo> loadedModInfos = StreamSupport.stream(loadedMods.spliterator(), false)
@@ -149,10 +147,8 @@ public class ConnectorLocator extends AbstractJarFileModProvider implements IDep
     }
 
     private Stream<Path> scanModsDir() {
-        List<Path> mods = new ArrayList<>();
-        ConnectorUtil.FABRIC_MODS_FOLDERS.forEach(path -> mods.addAll((uncheck(() -> Files.list(path))).toList()));
         List<Path> excluded = ModDirTransformerDiscoverer.allExcluded();
-        return mods.stream()
+        return uncheck(() -> Files.list(FMLPaths.MODSDIR.get()))
             .filter(p -> !excluded.contains(p) && StringUtils.toLowerCase(p.getFileName().toString()).endsWith(SUFFIX))
             .sorted(Comparator.comparing(path -> StringUtils.toLowerCase(path.getFileName().toString())))
             .filter(ConnectorLocator::isFabricModJar);

--- a/src/main/java/dev/su5ed/sinytra/connector/locator/ConnectorLocator.java
+++ b/src/main/java/dev/su5ed/sinytra/connector/locator/ConnectorLocator.java
@@ -177,7 +177,7 @@ public class ConnectorLocator extends AbstractJarFileModProvider implements IDep
     }
 
     private Stream<Path> scanArguments() {
-        Stream<Path> pathStream = Arrays.stream(System.getProperty("connector.addMods", "").split(File.pathSeparator)).map(Path::of);
+        Stream<Path> pathStream = Arrays.stream(System.getProperty("connector.additionalModLocations", "").split(",")).filter(s -> !s.isBlank()).map(Path::of);
         Stream.Builder<Path> ret = Stream.builder();
         pathStream.forEach(path -> {
             if (Files.isDirectory(path)) {

--- a/src/main/java/dev/su5ed/sinytra/connector/locator/ConnectorLocator.java
+++ b/src/main/java/dev/su5ed/sinytra/connector/locator/ConnectorLocator.java
@@ -103,7 +103,7 @@ public class ConnectorLocator extends AbstractJarFileModProvider implements IDep
             .toList();
         Collection<String> loadedModIds = loadedModInfos.stream().filter(mod -> !mod.library()).map(SimpleModInfo::modid).collect(Collectors.toUnmodifiableSet());
         // Discover fabric mod jars
-        List<JarTransformer.TransformableJar> discoveredJars = Stream.concat(scanModsDir(), scanClasspath())
+        List<JarTransformer.TransformableJar> discoveredJars = Stream.of(scanModsDir(), scanClasspath(), scanArguments()).flatMap(s -> s)
             .map(rethrowFunction(p -> cacheTransformableJar(p.toFile())))
             .filter(jar -> {
                 String modid = jar.modPath().metadata().modMetadata().getId();
@@ -174,6 +174,10 @@ public class ConnectorLocator extends AbstractJarFileModProvider implements IDep
             LOGGER.error(LogMarkers.SCAN, "Error trying to find resources", e);
             throw new RuntimeException(e);
         }
+    }
+
+    private Stream<Path> scanArguments() {
+        return Arrays.stream(System.getProperty("connector.addMods", "").split(File.pathSeparator)).map(Path::of);
     }
 
     private IModFile createConnectorModFile(SplitPackageMerger.FilteredModPath modPath) {


### PR DESCRIPTION
### Description
~~Replaces hardcoded `FMLPaths.MODSDIR` path with a configurable list of mods paths. This allows for greater flexibility, enabling other mods to seamlessly add other mods folders.~~

Adds `connector.additionalModLocations` property.
This allows to load extra fabric mods with

- the --connector.additionalModLocations program argument
- the -Dconnector.additionalModLocations jvm argument

Each takes a path separated by `,` e.g. `--connector.additionalModLocations=path/modA.jar,/some/path/modB.jar`.
It works as well on directories e.g. `--connector.additionalModLocations=some/path`.

### Motivation
This allows e.g. (future) [AutoModpack mod](https://modrinth.com/mod/automodpack) to load whole mods folder from completely different directory of modpack with Connector support. Tested to work fine with local dev version of the mod.
