### PR TITLE
Fix `preLaunch` entrypoint executing too late.

### DIFF
--- a/src/mod/java/dev/su5ed/sinytra/connector/mod/ConnectorBootstrap.java
+++ b/src/mod/java/dev/su5ed/sinytra/connector/mod/ConnectorBootstrap.java
@@ -20,7 +20,6 @@ public class ConnectorBootstrap implements IMixinConfigPlugin {
 
     static {
         registerCrashLogInfo();
-        ConnectorEarlyLoader.setup();
     }
 
     private static void registerCrashLogInfo() {

--- a/src/mod/java/dev/su5ed/sinytra/connector/mod/DummyTarget.java
+++ b/src/mod/java/dev/su5ed/sinytra/connector/mod/DummyTarget.java
@@ -1,0 +1,4 @@
+package dev.su5ed.sinytra.connector.mod;
+
+public class DummyTarget {
+}


### PR DESCRIPTION
This should fix issue #557.

Unfortunately, we need to replicate some FML loading stuff, specifically updating module reads and loading any transformable class. This way, Mixin initializes just before `preLaunch`, pretty much like on fabric.

Btw, it might be worth checking for early loading exceptions.

I quickly tested this on client, mainly with Andromeda and other Fabric mods. Shouldn't interfere with Forge mods. REIPC also works.