### PR TITLE
updated to work 47.2.16 forge

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ versionAdapter=1.9.0-1.20.1-20231215.155717
 versionAdapterDefinition=1.9.10
 
 versionMc=1.20.1
-versionForge=47.1.3
+versionForge=47.2.16
 versionForgeAutoRenamingTool=1.0.9
 versionFabricLoader=2.6.1+0.15.0+1.20.1
 versionFabricLoaderUpstream=0.15.0

--- a/src/mod/java/dev/su5ed/sinytra/connector/mod/mixin/ForgeHooksMixin.java
+++ b/src/mod/java/dev/su5ed/sinytra/connector/mod/mixin/ForgeHooksMixin.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(ForgeHooks.class)
 public abstract class ForgeHooksMixin {
 
-    @Inject(method = "getVanillaFluidType", at = @At(value = "NEW", target = "java/lang/RuntimeException"), remap = false, cancellable = true)
+    @Inject(method = "getVanillaFluidType", at = @At(value = "INVOKE", target = "Ljava/lang/RuntimeException;<init>(Ljava/lang/String;)V"), remap = false, cancellable = true)
     private static void getFabricVanillaFluidType(Fluid fluid, CallbackInfoReturnable<FluidType> cir) {
         FluidType fabricFluidType = FluidHandlerCompat.getFabricFluidType(fluid);
         if (fabricFluidType != null) {

--- a/src/mod/java/dev/su5ed/sinytra/connector/mod/mixin/registries/ForgeRegistryMixin.java
+++ b/src/mod/java/dev/su5ed/sinytra/connector/mod/mixin/registries/ForgeRegistryMixin.java
@@ -5,9 +5,12 @@ import com.mojang.serialization.Lifecycle;
 import dev.su5ed.sinytra.connector.mod.ConnectorLoader;
 import net.minecraft.core.Holder;
 import net.minecraft.core.MappedRegistry;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.registries.ForgeRegistry;
 import net.minecraftforge.registries.GameData;
 import net.minecraftforge.registries.IForgeRegistry;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -26,7 +29,7 @@ public abstract class ForgeRegistryMixin<V> implements IForgeRegistry<V> {
     private BiMap<Object, V> owners;
 
     // Mixin AP complained about not finding the target method, so we use @Desc instead of a string
-    @Inject(target = @Desc(value = "getDelegateOrThrow", args = Object.class, ret = Holder.Reference.class), at = @At("HEAD"), cancellable = true, remap = false)
+    @Inject(method = "getDelegateOrThrow(Ljava/lang/Object;)Lnet/minecraft/core/Holder$Reference;", at = @At("HEAD"), cancellable = true, remap = false)
     private void getDelegateOrThrow(V value, CallbackInfoReturnable<Holder.Reference<V>> cir) {
         if (!ConnectorLoader.hasFinishedLoading()) {
             cir.setReturnValue(getDelegate(value).orElseGet(() -> {
@@ -37,6 +40,38 @@ public abstract class ForgeRegistryMixin<V> implements IForgeRegistry<V> {
                 } catch (IllegalStateException e) {
                     // Fallback if the registry does not support intrusive holders
                     return Holder.Reference.createIntrusive(registry.holderOwner(), value);
+                }
+            }));
+        }
+    }
+
+    @Inject(method = "getDelegateOrThrow(Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/core/Holder$Reference;", at = @At("HEAD"), cancellable = true, remap = false)
+    private void getDelegateOrThrow(ResourceLocation value, CallbackInfoReturnable<Holder.Reference<V>> cir) {
+        if (!ConnectorLoader.hasFinishedLoading()) {
+            cir.setReturnValue(getDelegate(value).orElseGet(() -> {
+                MappedRegistry<V> registry = GameData.getWrapper(getRegistryKey(), Lifecycle.stable());
+                try {
+                    // Create intrusive holder on the registry to bind the key later
+                    return registry.createIntrusiveHolder(registry.get(value));
+                } catch (IllegalStateException e) {
+                    // Fallback if the registry does not support intrusive holders
+                    return Holder.Reference.createIntrusive(registry.holderOwner(), registry.get(value));
+                }
+            }));
+        }
+    }
+
+    @Inject(method = "getDelegateOrThrow(Lnet/minecraft/resources/ResourceKey;)Lnet/minecraft/core/Holder$Reference;", at = @At("HEAD"), cancellable = true, remap = false)
+    private void getDelegateOrThrow(ResourceKey<V> value, CallbackInfoReturnable<Holder.Reference<V>> cir) {
+        if (!ConnectorLoader.hasFinishedLoading()) {
+            cir.setReturnValue(getDelegate(value).orElseGet(() -> {
+                MappedRegistry<V> registry = GameData.getWrapper(getRegistryKey(), Lifecycle.stable());
+                try {
+                    // Create intrusive holder on the registry to bind the key later
+                    return registry.createIntrusiveHolder(registry.get(value));
+                } catch (IllegalStateException e) {
+                    // Fallback if the registry does not support intrusive holders
+                    return Holder.Reference.createIntrusive(registry.holderOwner(), registry.get(value));
                 }
             }));
         }


### PR DESCRIPTION
## The Issue

Doesn't work with forge 47.2.16

## The Proposal

Make it work with forge 47.2.16

## Possible Side Effects

You can use Connector with forge 47.2.16

## Alternatives

Its a forge version bump not an intricate api.

## Additional Notes

I'm doing this PR for other parties who need it on 47.2.16. A tempoary fork was posted on curseforge until this is accepted.