### PR TITLE
make alias between embeddium and sodium

### DIFF
--- a/src/main/java/dev/su5ed/sinytra/connector/ConnectorUtil.java
+++ b/src/main/java/dev/su5ed/sinytra/connector/ConnectorUtil.java
@@ -116,7 +116,8 @@ public final class ConnectorUtil {
     // They're too annoying to override individually in each mod, so we provide this small QoL feature for the user's comfort
     public static final Multimap<String, String> DEFAULT_GLOBAL_MOD_ALIASES = ImmutableMultimap.of(
         "cloth_config", "cloth-config2",
-        "playeranimator", "player-animator"
+        "playeranimator", "player-animator",
+        "embeddium", "sodium"
     );
 
     private static final boolean CACHE_ENABLED;


### PR DESCRIPTION
## The Issue

automatically make alias between embeddium and sodium to avoid issue of people have incompat with axiom or immersive portal.

## The Proposal

add the alias

## Alternatives

An alternative is just to have embeddium add him as sodium like he did with rubidium for occulus
