### PR TITLE
Refuse to load Fabric mods on wrong side. Fixes #904.

### DIFF
--- a/src/main/java/dev/su5ed/sinytra/connector/locator/ConnectorLocator.java
+++ b/src/main/java/dev/su5ed/sinytra/connector/locator/ConnectorLocator.java
@@ -237,7 +237,7 @@ public class ConnectorLocator extends AbstractJarFileModProvider implements IDep
             .flatMap(path -> {
                 JarTransformer.TransformableJar jar = uncheck(() -> prepareNestedJar(tempDir, secureJar.getPrimaryPath().getFileName().toString(), path));
                 ConnectorLoaderModMetadata metadata = jar.modPath().metadata().modMetadata();
-                if (shouldIgnoreMod(metadata.getId(), loadedModIds)) {
+                if (shouldIgnoreMod(metadata, loadedModIds)) {
                     return Stream.empty();
                 }
                 parentToChildren.put(parent, jar);

--- a/src/main/java/dev/su5ed/sinytra/connector/locator/ConnectorLocator.java
+++ b/src/main/java/dev/su5ed/sinytra/connector/locator/ConnectorLocator.java
@@ -291,7 +291,7 @@ public class ConnectorLocator extends AbstractJarFileModProvider implements IDep
     }
 
     private static boolean shouldIgnoreMod(ConnectorLoaderModMetadata metadata, Collection<String> loadedModIds) {
-        if (!metadata.loadsInEnvironment(FabricLoader.getInstance().getEnvironmentType())) return false;
+        if (!metadata.loadsInEnvironment(FabricLoader.getInstance().getEnvironmentType())) return true;
         String id = metadata.getId();
         return ConnectorUtil.DISABLED_MODS.contains(id) || loadedModIds.contains(id);
     }


### PR DESCRIPTION
## The Issue

Sinytra Connector loads some mods on the wrong side. This causes crash: #924 #904

## The Proposal

Refuse to load mods on the wrong side.

## Possible Side Effects

I don't think there is any possible side effects.

## Alternatives

#908, 2bc9aee. This solution doesn't fix the real problem.

## Additional Notes
No.
