### PR TITLE
Don't classload FluidRenderHandler on dedicated server

### DIFF
--- a/src/mod/java/org/sinytra/connector/mod/compat/FluidHandlerCompat.java
+++ b/src/mod/java/org/sinytra/connector/mod/compat/FluidHandlerCompat.java
@@ -1,8 +1,6 @@
 package org.sinytra.connector.mod.compat;
 
 import com.mojang.logging.LogUtils;
-import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandler;
-import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandlerRegistry;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariantAttributes;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -16,7 +14,6 @@ import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.FluidType;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
 import net.neoforged.neoforge.registries.RegisterEvent;
-import org.jetbrains.annotations.Nullable;
 import org.sinytra.connector.ConnectorEarlyLoader;
 import org.slf4j.Logger;
 
@@ -51,8 +48,7 @@ public final class FluidHandlerCompat {
             ResourceKey<Fluid> key = entry.getKey();
             Fluid fluid = entry.getValue();
             if (ModList.get().getModContainerById(key.location().getNamespace()).map(c -> ConnectorEarlyLoader.isConnectorMod(c.getModId())).orElse(false)) {
-                FluidRenderHandler renderHandler = FluidRenderHandlerRegistry.INSTANCE.get(fluid);
-                FluidType type = new FabricFluidType(FluidType.Properties.create(), fluid, renderHandler);
+                FluidType type = new FabricFluidType(FluidType.Properties.create(), fluid);
                 FABRIC_FLUID_TYPES.put(fluid, type);
                 FABRIC_FLUID_TYPES_BY_NAME.put(key.location(), type);
             }
@@ -64,18 +60,11 @@ public final class FluidHandlerCompat {
     }
 
     static class FabricFluidType extends FluidType {
-        @Nullable
-        private final FluidRenderHandler renderHandler;
         private final Component name;
 
-        public FabricFluidType(Properties properties, Fluid fluid, @Nullable FluidRenderHandler renderHandler) {
+        public FabricFluidType(Properties properties, Fluid fluid) {
             super(properties);
-            this.renderHandler = renderHandler;
             this.name = FluidVariantAttributes.getName(FluidVariant.of(fluid));
-        }
-
-        public FluidRenderHandler getRenderHandler() {
-            return renderHandler;
         }
 
         @Override

--- a/src/mod/java/org/sinytra/connector/mod/compat/FluidHandlerCompatClient.java
+++ b/src/mod/java/org/sinytra/connector/mod/compat/FluidHandlerCompatClient.java
@@ -1,6 +1,7 @@
 package org.sinytra.connector.mod.compat;
 
 import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandler;
+import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandlerRegistry;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
@@ -14,7 +15,7 @@ public final class FluidHandlerCompatClient {
 
     public static void onRegisterClientExtensions(RegisterClientExtensionsEvent event) {
         FluidHandlerCompat.getFabricFluidTypes().forEach((fluid, type) -> {
-            FluidRenderHandler renderHandler = ((FluidHandlerCompat.FabricFluidType) type).getRenderHandler();
+            FluidRenderHandler renderHandler = FluidRenderHandlerRegistry.INSTANCE.get(fluid);
             event.registerFluidType(new IClientFluidTypeExtensions() {
                 private TextureAtlasSprite[] getSprites() {
                     return renderHandler.getFluidSprites(null, null, fluid.defaultFluidState());

--- a/src/mod/resources/connector.mixins.json
+++ b/src/mod/resources/connector.mixins.json
@@ -13,15 +13,12 @@
     "item.IItemExtensionMixin",
     "item.ItemStackMixin",
     "network.StreamCodecMixin",
-    "recipebook.RecipeBookCategoriesAccessor",
-    "recipebook.RecipeBookCategoriesMixin",
     "recipebook.RecipeBookManagerMixin",
     "registries.DataPackRegistriesHooksAccessor",
     "registries.MappedRegistryAccessor",
     "registries.NeoForgeRegistriesSetupAccessor",
     "registries.BuiltInRegistriesMixin",
     "registries.EntityDataSerializersMixin",
-    "registries.ItemBlockRenderTypesMixin",
     "registries.NeoForgeRegistriesSetupMixin",
     "registries.NetworkRegistryMixin",
     "registries.PoiTypesMixin",
@@ -34,7 +31,10 @@
     "client.ItemColorsMixin",
     "client.ItemOverridesMixin",
     "client.KeyMappingMixin",
-    "client.ParticleEngineMixin"
+    "client.ParticleEngineMixin",
+    "recipebook.RecipeBookCategoriesAccessor",
+    "recipebook.RecipeBookCategoriesMixin",
+    "registries.ItemBlockRenderTypesMixin"
   ],
   "server": [
     "boot.ServerMainMixin"


### PR DESCRIPTION
## The Issue

The `FluidRenderHandler` class is classloaded during mod init (specifically `FluidHandlerCompat#initFabricFluidTypes`) on dedicated servers, causing a crash due to the classloading of the client-only class `TextureAtlasSprite`.

## The Proposal

The access to `FluidRenderHandlerRegistry` has been moved from `FluidHandlerCompat#initFabricFluidTypes` to `FluidHandlerCompatClient#onRegisterClientExtensions`.

## Possible Side Effects

None that I can think of.

## Alternatives

It's possible an `@OnlyIn(Dist.CLIENT)` marker somewhere might also work?

## Additional Notes

See https://github.com/Sinytra/Connector/issues/1501 for a more complete description of the issue.

Additionally, the mixins that should only be loaded on the client have been marked as such in the `.mixins.json`, silencing a few warnings in the logs on dedicated servers.