### PR TITLE
Make RecipeBookManagerMixin clientside

### DIFF
--- a/src/mod/resources/connector.mixins.json
+++ b/src/mod/resources/connector.mixins.json
@@ -13,7 +13,6 @@
     "item.IItemExtensionMixin",
     "item.ItemStackMixin",
     "network.StreamCodecMixin",
-    "recipebook.RecipeBookManagerMixin",
     "registries.DataPackRegistriesHooksAccessor",
     "registries.MappedRegistryAccessor",
     "registries.NeoForgeRegistriesSetupAccessor",
@@ -34,6 +33,7 @@
     "client.ParticleEngineMixin",
     "recipebook.RecipeBookCategoriesAccessor",
     "recipebook.RecipeBookCategoriesMixin",
+    "recipebook.RecipeBookManagerMixin",
     "registries.ItemBlockRenderTypesMixin"
   ],
   "server": [


### PR DESCRIPTION
This class isn't marked as OnlyIn(Dist.CLIENT), but it is in NeoForge's client package. It also references many classes which are marked as client, so loading this mixin would cause issues on a server.

Normally, this is not noticeable since this class won't be accessed from the server. But it is still wrong and when a mixin audit is run this will cause a crash.