### PR TITLE
Wrap thread factory set context class loader in a try

### DIFF
--- a/src/main/java/org/sinytra/connector/service/hacks/ConnectorForkJoinThreadFactory.java
+++ b/src/main/java/org/sinytra/connector/service/hacks/ConnectorForkJoinThreadFactory.java
@@ -21,7 +21,11 @@ public class ConnectorForkJoinThreadFactory implements ForkJoinPool.ForkJoinWork
     @Override
     public ForkJoinWorkerThread newThread(ForkJoinPool pool) {
         ForkJoinWorkerThread thread = this.factory.newThread(pool);
-        thread.setContextClassLoader(Thread.currentThread().getContextClassLoader());
+        try {
+            thread.setContextClassLoader(Thread.currentThread().getContextClassLoader());
+        } catch (Exception e) {
+            System.out.println("Sinytra Connector: Error trying to create new thread: " + e);
+        }
         return thread;
     }
 


### PR DESCRIPTION
## The Issue

I was experiencing a rare crash upon starting a Create contraption and opening a Tom's Storage terminal blaming Sinytras Thread Factory ["setContextClassLoader"](https://github.com/Sinytra/Connector/blob/1.21.x/src/main/java/org/sinytra/connector/service/hacks/ConnectorForkJoinThreadFactory.java#L24) line. I was unable to reproduce it with a minimal set of mods, nor was i able to reproduce it consistently in a reasonable time frame (took 10+ hours to reproduce once)

Tom's Storage: https://pastebin.com/xW0sDscN
Create: https://pastebin.com/E2bYNWKJ

While the crash with the Tom's Storage Terminal was savable (a simple re-log fixed it) the Create crash would delete all active contraptions in my world. 
Neruina was capable of catching the Tom's Storage Terminal crash and recover with no side effects, but it was unable to catch the Create crash at all.

## The Proposal

Wrap thread factory set context class loader in a try

## Possible Side Effects

if anything ever tries to check what the class loader context is on a thread after the try failed, possible crash/error? I've not had any issues with 200+ hours playing on a very large modpack after making this change though.

## Alternatives

I'll be honest, im not familiar with managing threads at all, im still a fairly novice modder. I'm not sure what the alternative would be, especially without knowing exactly why its happening in the first place.

## Additional Notes
Apologies I know I wasnt able to properly reproduce the issue, which is why I have not made an issue about it, however I thought I'd atleast report my findings as I believe I've found a solution. After making this change, I have not been able to intentionally recreate the crash with Tom's Storage or Create, and have been playing normally on my world for 200+ hours since with no related issues. I have seen the log output I added to the catch a handful of times, and not seen any abnormalities in gameplay other than a very brief lag spike surrounding it.

I left the log output on catch in, just in case it ever pops up in issues in the future it will be easier to be related to this, and with how rare this case is, this wont result in log spam.
