### PR TITLE
Fix mythic metal

### DIFF
--- a/src/main/java/org/sinytra/connector/transformer/MixinPatches.java
+++ b/src/main/java/org/sinytra/connector/transformer/MixinPatches.java
@@ -113,17 +113,10 @@ public class MixinPatches {
                 .targetMethod("render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V")
                 .targetInjectionPoint("Lnet/minecraft/client/renderer/entity/layers/ElytraLayer;shouldRender(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/LivingEntity;)Z")
                 .modifyParams(builder -> builder
-                    .insert(1, Type.getObjectType("com/mojang/blaze3d/vertex/PoseStack"))
-                    .insert(2, Type.getObjectType("net/minecraft/client/renderer/MultiBufferSource"))
-                    .insert(3, Type.INT_TYPE)
-                    .swap(2, 4)
-                    .insert(4, Type.FLOAT_TYPE)
-                    .insert(5, Type.FLOAT_TYPE)
-                    .insert(6, Type.FLOAT_TYPE)
-                    .insert(7, Type.FLOAT_TYPE)
-                    .insert(8, Type.FLOAT_TYPE)
-                    .insert(9, Type.FLOAT_TYPE)
-                    )
+                    .remove(1)
+                    .insert(2, Type.getObjectType("com/mojang/blaze3d/vertex/PoseStack"))
+                    .insert(3, Type.getObjectType("net/minecraft/client/renderer/MultiBufferSource"))
+                    .insert(4, Type.INT_TYPE))
                 .build(),
             // NeoForge moves this behaviour out completely with no viable replacement, so we disable it for now
             Patch.builder()

--- a/src/main/java/org/sinytra/connector/transformer/MixinPatches.java
+++ b/src/main/java/org/sinytra/connector/transformer/MixinPatches.java
@@ -108,6 +108,23 @@ public class MixinPatches {
                     return Patch.Result.APPLY;
                 })
                 .build(),
+            Patch.builder()
+                .targetClass("net/minecraft/client/renderer/entity/layers/ElytraLayer")
+                .targetMethod("render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V")
+                .targetInjectionPoint("Lnet/minecraft/client/renderer/entity/layers/ElytraLayer;shouldRender(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/LivingEntity;)Z")
+                .modifyParams(builder -> builder
+                    .insert(1, Type.getObjectType("com/mojang/blaze3d/vertex/PoseStack"))
+                    .insert(2, Type.getObjectType("net/minecraft/client/renderer/MultiBufferSource"))
+                    .insert(3, Type.INT_TYPE)
+                    .swap(2, 4)
+                    .insert(4, Type.FLOAT_TYPE)
+                    .insert(5, Type.FLOAT_TYPE)
+                    .insert(6, Type.FLOAT_TYPE)
+                    .insert(7, Type.FLOAT_TYPE)
+                    .insert(8, Type.FLOAT_TYPE)
+                    .insert(9, Type.FLOAT_TYPE)
+                    )
+                .build(),
             // NeoForge moves this behaviour out completely with no viable replacement, so we disable it for now
             Patch.builder()
                 .targetClass("net/minecraft/world/entity/animal/SnowGolem", "net/minecraft/world/entity/animal/Sheep", "net/minecraft/world/entity/animal/MushroomCow")


### PR DESCRIPTION
## The Issue

Fix mixin in mythic metal mixin.

## The Proposal

Connector change the function signature so mixin complain, I just add a patch to revert that, probably not the best.

## Possible Side Effects

maybe also fix one mixin of origins (not all). or other mod who interact with elytra have their mixin make problem.

## Alternatives

Fix adapter to not change the function signature.

## Additional Notes

None
