### PR TITLE
Fix ConnectorCoremods creativeModeTabConstructorTransform

### DIFF
--- a/src/main/java/org/sinytra/connector/ConnectorCoremods.java
+++ b/src/main/java/org/sinytra/connector/ConnectorCoremods.java
@@ -67,15 +67,13 @@ public class ConnectorCoremods implements ICoreMod {
                 method.visitVarInsn(Opcodes.ALOAD, 5);
                 // displayItemsGenerator
                 method.visitVarInsn(Opcodes.ALOAD, 6);
-                // backgroundLocation
-                method.visitTypeInsn(Opcodes.NEW, "net/minecraft/resources/ResourceLocation");
-                method.visitInsn(Opcodes.DUP);
-                method.visitLdcInsn("textures/gui/container/creative_inventory/tab_items.png");
-                method.visitMethodInsn(Opcodes.INVOKESPECIAL, "net/minecraft/resources/ResourceLocation", "<init>", "(Ljava/lang/String;)V", false);
+                // scrollerSpriteLocation
+                method.visitInsn(Opcodes.ACONST_NULL);
                 // hasSearchBar
                 method.visitInsn(Opcodes.ICONST_0);
                 // searchBarWidth
                 method.visitLdcInsn(89);
+                // tabsImage
                 method.visitFieldInsn(Opcodes.GETSTATIC, "net/minecraft/world/item/CreativeModeTab$Builder", "CREATIVE_INVENTORY_TABS_IMAGE", "Lnet/minecraft/resources/ResourceLocation;"); // tabsImage
                 // labelColor
                 method.visitLdcInsn(4210752);


### PR DESCRIPTION
## The Issue

The transformer in ConnectorCoremods that injected the vanilla CreativeModeTab constructor wasn't using the correct placeholder types to invoke the NeoForge CreativeModeTab constructor, causing a crash if any Fabric mod attempted to invoke the vanilla CreativeModeTab constructor directly

## The Proposal

Adjust the placeholder types to invoke the NeoForge constructor properly

## Possible Side Effects

None

## Alternatives

None
