### PR TITLE
`ConnectorEarlyLoader#hasEncounteredException`: check `LoadingModList#hasErrors` instead of `LoadingModList#getModLoadingIssues != empty`

### DIFF
--- a/src/main/java/org/sinytra/connector/ConnectorEarlyLoader.java
+++ b/src/main/java/org/sinytra/connector/ConnectorEarlyLoader.java
@@ -52,7 +52,7 @@ public class ConnectorEarlyLoader {
      * @return Whether a loading exception has been encountered up to this point in loading
      */
     public static boolean hasEncounteredException() {
-        return !LOADING_EXCEPTIONS.isEmpty() || LoadingModList.get() != null && !LoadingModList.get().getModLoadingIssues().isEmpty();
+        return !LOADING_EXCEPTIONS.isEmpty() || LoadingModList.get() != null && LoadingModList.get().hasErrors();
     }
 
     /**


### PR DESCRIPTION
## The Issue

Connector will refuse to load Fabric mods if NeoForge encounters an error *or* warning, which is problematic when a warning is non-fatal, thus allowing the game to continue to load and Fabric mods to act erratically

## The Proposal

Check for `LoadingModList.get().hasErrors()` instead of `!LoadingModList.get().getModLoadingIssues().isEmpty()` in `ConnectorEarlyLoader#hasEncounteredException`, which will only return `true` if fatal errors have been encountered instead of including non-fatal warnings

## Possible Side Effects

Perhaps there was a reason all mod loading issues were checked for, instead of only true errors?

## Alternatives

Throw a `RuntimeException` in `ConnectorEarlyLoader#init` if `ConnectorEarlyLoader#hasEncounteredException == true`: this would not help with the confusion that stems from NeoForge not printing mod loading issues to the log before it reaches its "pre-title screen" screen (although these issues could also be printed by Connector before throwing, I suppose)

## Additional Notes

Cool mod thanks
