### PR TITLE
Update to Forge 47.4.6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ versionAdapterDefinition=1.11.67-1.20.1
 versionAdapterRuntime=1.0.0
 
 versionMc=1.20.1
-versionForge=47.1.3
+versionForge=47.4.6
 versionForgeAutoRenamingTool=1.0.11
 versionFabricLoader=2.7.10+0.16.5+1.20.1
 versionAccessWidener=2.1.0


### PR DESCRIPTION
## The Issue

The mod could boot on Forge 47.4.6, so why not just go to that version?

Forge 47.1.3 is **TOO OLD** to be used with MC 1.20.1, newer version of lots of mods has been on newer Forge.

Related: https://github.com/Sinytra/ForgifiedFabricAPI/pull/239 and https://github.com/Sinytra/ForgeAutoRenamingTool/pull/1

## The Proposal

Clarify that the mod is compatible with latest Forge.

I know there might be a lot of mods still not compatible with Connector, but it should not be the reason for being on an out-dated Forge version.

## Possible Side Effects

Encourage users to use Connector on MC 1.20.1.
I understand that this branch of Connector may not actively maintained at this moment, but give users chance to try on it.

## Alternatives

No. Stay on old Forge? That does not make any change on making the incompatible mods work, but upgrading the Forge version would let us be compatible with more mods that are actively maintained.

## Additional Notes

None.