### PR TITLE
Add compatibility with Forge's update checker and Catalogue modmenu

### DIFF
--- a/src/main/java/org/sinytra/connector/locator/ConnectorModMetadataParser.java
+++ b/src/main/java/org/sinytra/connector/locator/ConnectorModMetadataParser.java
@@ -2,6 +2,7 @@ package org.sinytra.connector.locator;
 
 import com.electronwill.nightconfig.core.Config;
 import com.mojang.logging.LogUtils;
+import net.fabricmc.loader.api.metadata.CustomValue;
 import org.sinytra.connector.ConnectorUtil;
 import org.sinytra.connector.loader.ConnectorLoaderModMetadata;
 import net.fabricmc.loader.api.metadata.ContactInformation;
@@ -20,6 +21,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -61,6 +63,20 @@ public final class ConnectorModMetadataParser {
         modListConfig.add("displayName", metadata.getName());
         modListConfig.add("description", metadata.getDescription());
         metadata.getIconPath(-1).ifPresent(icon -> modListConfig.add("logoFile", icon));
+
+        // Ensure string is valid url
+        Predicate<String> isValidUrl = str -> {
+            if(str == null) {
+                return false;
+            }
+            try {
+                new URL(str);
+                return true;
+            } catch (MalformedURLException e) {
+                return false;
+            }
+        };
+
         ContactInformation contact = metadata.getContact();
         contact.get("homepage")
             .or(() -> contact.get("source"))
@@ -68,18 +84,22 @@ public final class ConnectorModMetadataParser {
                 .filter(m -> !m.isEmpty())
                 .map(m -> m.entrySet().iterator().next().getValue()))
             // Ensure string is valid url
-            .filter(str -> {
-                try {
-                    new URL(str);
-                    return true;
-                } catch (MalformedURLException e) {
-                    return false;
-                }
-            })
+            .filter(isValidUrl)
             .ifPresent(url -> {
                 modListConfig.add("modUrl", url);
                 modListConfig.add("displayURL", url);
             });
+        contact.get("issues")
+            .filter(isValidUrl)
+            .ifPresent(url -> modListConfig.add("issueTrackerURL",url));
+
+        // Forge's update checker compat
+        Optional.ofNullable(metadata.getCustomValues().get("forgeUpdateJSONURL"))
+            .filter(va -> va.getType() == CustomValue.CvType.STRING)
+            .map(CustomValue::getAsString)
+            .filter(isValidUrl)
+            .ifPresent(url -> modListConfig.add("updateJSONURL",url));
+
         modListConfig.add("authors", metadata.getAuthors().stream()
             .map(Person::getName)
             .collect(Collectors.joining(", ")));


### PR DESCRIPTION
Add compatibility with Forge's update checker (via custom property `forgeUpdateJSONURL`) + Added compatibility with the Catalogue modmenu (submit bug url)

## The Issue

Currently, mods loaded via Connector cannot use (Neo)Forge's update checker. Moreover, the bug tracker URL doesn't seem to be set, which prevents some modmenus like Catalogue from displaying a "Sumbit bug report" button on the mod's page.

## The Proposal

This pull request proposes to add support for this update checker by setting the mod's `updateJSONURL` to the value of a custom attribute in its `fabric.mod.json` named `forgeUpdateJSONURL`.
Also, the `issueTrackerURL` is set to the value of the `issues` field in the contact information.

## Possible Side Effects

Probably none. The Forge's update checker will only be used if the mod has a `forgeUpdateJSONURL` custom field in its manifest. 

Maybe the bug report URL should be changed to a confirmation page about this mod being loaded with Connector (maybe something like https://sinytra.org/connector_warning?redirect_to=<actual mod bug tracker>).

## Alternatives

While most players probably use launchers to manage their mods, adding compatibility with Forge's update checker will also notify players on the main menu (moreover the changes in themselves are pretty small).

Also, making Forge aware of the mod's bug report URL could maybe help in easier bug reports for players (as mentioned in Possible Side Effects maybe it should first redirect to a confirmation page).

Maybe the PR should be split in 2 (one for the Forge update checker and one for the issue tracker) ?

## Additional Notes
I'm not a native English speaker, and this is my first public PR

If this PR is successful I will probably also port it to the 1.21.1 branch