### PR TITLE
Fix Fabric fluid sprite reload before Forge texture stitch event dispatch

### DIFF
--- a/src/mod/java/org/sinytra/connector/mod/compat/FluidHandlerCompat.java
+++ b/src/mod/java/org/sinytra/connector/mod/compat/FluidHandlerCompat.java
@@ -6,7 +6,9 @@ import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandler;
 import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandlerRegistry;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariantAttributes;
+import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.renderer.texture.MissingTextureAtlasSprite;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
@@ -24,8 +26,11 @@ import net.minecraftforge.registries.RegisterEvent;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 
 public final class FluidHandlerCompat {
@@ -36,6 +41,20 @@ public final class FluidHandlerCompat {
     public static void init(IEventBus bus) {
         initFabricFluidTypes();
         bus.addListener(FluidHandlerCompat::onRegisterFluids);
+    }
+
+    public static void reloadFluidTextures(TextureAtlas atlas) {
+        if (!TextureAtlas.LOCATION_BLOCKS.equals(atlas.location())) {
+            return;
+        }
+
+        Set<FluidRenderHandler> reloadedHandlers = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (Fluid fluid : FABRIC_FLUID_TYPES.keySet()) {
+            FluidRenderHandler renderHandler = FluidRenderHandlerRegistry.INSTANCE.get(fluid);
+            if (renderHandler != null && reloadedHandlers.add(renderHandler)) {
+                renderHandler.reloadTextures(atlas);
+            }
+        }
     }
 
     public static FluidType getFabricFluidType(Fluid fluid) {
@@ -52,8 +71,7 @@ public final class FluidHandlerCompat {
             ResourceKey<Fluid> key = entry.getKey();
             Fluid fluid = entry.getValue();
             if (ModList.get().getModContainerById(key.location().getNamespace()).map(c -> ConnectorEarlyLoader.isConnectorMod(c.getModId())).orElse(false)) {
-                FluidRenderHandler renderHandler = FluidRenderHandlerRegistry.INSTANCE.get(fluid);
-                FluidType type = new FabricFluidType(FluidType.Properties.create(), fluid, renderHandler);
+                FluidType type = new FabricFluidType(FluidType.Properties.create(), fluid);
                 FABRIC_FLUID_TYPES.put(fluid, type);
                 FABRIC_FLUID_TYPES_BY_NAME.put(key.location(), type);
             }
@@ -67,14 +85,11 @@ public final class FluidHandlerCompat {
     @SuppressWarnings("UnstableApiUsage")
     private static class FabricFluidType extends FluidType {
         private final Fluid fluid;
-        @Nullable
-        private final FluidRenderHandler renderHandler;
         private final Component name;
 
-        public FabricFluidType(Properties properties, Fluid fluid, @Nullable FluidRenderHandler renderHandler) {
+        public FabricFluidType(Properties properties, Fluid fluid) {
             super(properties);
             this.fluid = fluid;
-            this.renderHandler = renderHandler;
             this.name = FluidVariantAttributes.getName(FluidVariant.of(fluid));
         }
 
@@ -91,37 +106,66 @@ public final class FluidHandlerCompat {
         @Override
         public void initializeClient(Consumer<IClientFluidTypeExtensions> consumer) {
             consumer.accept(new IClientFluidTypeExtensions() {
+                private final boolean[] missingSpriteWarnings = new boolean[2];
+
+                @Nullable
+                private FluidRenderHandler getRenderHandler() {
+                    return FluidRenderHandlerRegistry.INSTANCE.get(fluid);
+                }
+
                 private TextureAtlasSprite[] getSprites() {
-                    return renderHandler.getFluidSprites(null, null, fluid.defaultFluidState());
+                    FluidRenderHandler renderHandler = getRenderHandler();
+                    return renderHandler == null
+                            ? new TextureAtlasSprite[0]
+                            : renderHandler.getFluidSprites(null, null, fluid.defaultFluidState());
+                }
+
+                private ResourceLocation spriteName(TextureAtlasSprite[] sprites, int index, String kind) {
+                    if (sprites == null || sprites.length <= index || sprites[index] == null) {
+                        if (!missingSpriteWarnings[index]) {
+                            LOGGER.warn("Missing {} sprite for Fabric fluid {}", kind, ForgeRegistries.FLUIDS.getKey(fluid));
+                            missingSpriteWarnings[index] = true;
+                        }
+                        return MissingTextureAtlasSprite.getLocation();
+                    }
+                    return sprites[index].contents().name();
                 }
 
                 @Override
                 public ResourceLocation getStillTexture() {
-                    TextureAtlasSprite[] sprites = getSprites();
-                    return sprites[0].contents().name();
+                    return spriteName(getSprites(), 0, "still");
                 }
 
                 @Override
                 public ResourceLocation getFlowingTexture() {
-                    TextureAtlasSprite[] sprites = getSprites();
-                    return sprites[1].contents().name();
+                    return spriteName(getSprites(), 1, "flowing");
                 }
 
                 @Nullable
                 @Override
                 public ResourceLocation getOverlayTexture() {
                     TextureAtlasSprite[] sprites = getSprites();
-                    return sprites.length > 2 ? sprites[2].contents().name() : null;
+                    return sprites != null && sprites.length > 2 && sprites[2] != null
+                            ? sprites[2].contents().name()
+                            : null;
                 }
 
                 @Override
                 public int getTintColor() {
+                    FluidRenderHandler renderHandler = getRenderHandler();
+                    if (renderHandler == null) {
+                        return 0xFFFFFFFF;
+                    }
                     int baseColor = renderHandler.getFluidColor(null, null, fluid.defaultFluidState());
                     return 0xFF000000 | baseColor;
                 }
 
                 @Override
                 public int getTintColor(FluidState state, BlockAndTintGetter getter, BlockPos pos) {
+                    FluidRenderHandler renderHandler = getRenderHandler();
+                    if (renderHandler == null) {
+                        return 0xFFFFFFFF;
+                    }
                     int baseColor = renderHandler.getFluidColor(getter, pos, state);
                     return 0xFF000000 | baseColor;
                 }

--- a/src/mod/java/org/sinytra/connector/mod/mixin/ForgeHooksClientMixin.java
+++ b/src/mod/java/org/sinytra/connector/mod/mixin/ForgeHooksClientMixin.java
@@ -2,13 +2,16 @@ package org.sinytra.connector.mod.mixin;
 
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
+import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.network.chat.FormattedText;
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.client.ForgeHooksClient;
+import org.sinytra.connector.mod.compat.FluidHandlerCompat;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.ArrayList;
@@ -17,6 +20,13 @@ import java.util.Optional;
 
 @Mixin(ForgeHooksClient.class)
 public abstract class ForgeHooksClientMixin {
+
+    @Inject(method = "onTextureStitchedPost", at = @At("HEAD"), remap = false)
+    private static void connector$reloadFabricFluidTextures(TextureAtlas atlas, CallbackInfo ci) {
+        // Fabric initializes cached fluid sprites during its renderer reload, which runs after
+        // Forge mods can first query them from TextureStitchEvent.Post.
+        FluidHandlerCompat.reloadFluidTextures(atlas);
+    }
 
     @Inject(method = "gatherTooltipComponents(Lnet/minecraft/world/item/ItemStack;Ljava/util/List;Ljava/util/Optional;IIILnet/minecraft/client/gui/Font;)Ljava/util/List;", at = @At("RETURN"), remap = false, cancellable = true)
     private static void makeTooltipComponentListMutable(ItemStack stack, List<? extends FormattedText> textElements, Optional<TooltipComponent> itemComponent, int mouseX, int screenWidth, int screenHeight, Font fallbackFont, CallbackInfoReturnable<List<ClientTooltipComponent>> cir) {


### PR DESCRIPTION
## The Issue

Fabric's `SimpleFluidRenderHandler` creates its sprite array before the entries are populated. The entries are initialized later through `FluidRenderHandler.reloadTextures(...)` during Fabric's fluid renderer reload.

On Forge, `TextureStitchEvent.Post` can be dispatched before that Fabric reload has run. Forge mods may query Connector's bridged `IClientFluidTypeExtensions` from this event and receive an array whose still and flowing entries are still `null`.

BuildCraft exposes this ordering issue by querying the still texture from its `TextureStitchEvent.Post` listener. Connector then dereferences `sprites[0]`, causing resource loading to fail before the main menu is reached.

Downstream report and stack trace: https://github.com/yu1745/ic2-fabric/issues/18

## The Proposal

Reload Fabric fluid render handlers at the head of `ForgeHooksClient.onTextureStitchedPost(...)`, before Forge dispatches `TextureStitchEvent.Post` to mod event buses.

The implementation:

- only reloads handlers for the block texture atlas;
- deduplicates shared handlers by identity, since still and flowing fluids may use the same handler;
- resolves handlers from `FluidRenderHandlerRegistry` when they are used, instead of permanently caching a possibly early `null` result;
- keeps missing-sprite handling as a final fallback;
- returns the default white tint if no render handler is registered;
- logs each missing still/flowing sprite warning only once.

This initializes real Fabric fluid sprites before any Forge mod can query the bridge, while retaining safe behavior for genuinely incomplete fluid render handlers.

## Possible Side Effects

Each unique Fabric fluid render handler receives an additional `reloadTextures(...)` call when the block atlas finishes stitching. This is the lifecycle operation the Fabric API expects for cached fluid sprites.

The reload runs before Forge's post-stitch event subscribers rather than later during Fabric's fluid renderer reload. Handlers are deduplicated, and non-block atlases are ignored.

Invalid or missing handlers now produce a missing texture/default tint instead of crashing resource loading.

## Alternatives

Registering a `TextureStitchEvent.Post` listener with `EventPriority.HIGHEST` was considered, but Forge dispatches mod-bus events to mod containers in sorted mod order. Listener priority therefore cannot guarantee that Connector runs before another mod such as BuildCraft.

Reloading textures from every still/flowing texture getter was also considered, but that performs lifecycle mutation during ordinary queries and may repeat the reload unnecessarily.

Only returning the missing texture prevents the crash but leaves valid Fabric fluids visually broken and does not address the resource-loading order.

## Additional Notes

Base: current `1.20.1` branch at `7411b51ef26b335887810c0c8769187886a54fba`.

Validation:

- `PUBLISH_RELEASE_TYPE=BETA ./gradlew clean build` succeeds.
- Manually tested with Minecraft 1.20.1, Forge 47.4.20, Connector beta49, BuildCraft Lib 7.99.24.9, and IC2 Refabricated.
- The client completes resource loading and reaches the main menu without the original null-sprite crash.
