### PR TITLE
Adapt 26.1 Fabric metadata and mixin transformations

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,12 +7,12 @@ org.gradle.caching=true
 
 # Versions
 versionConnector=3.0.0-beta.2
-versionAdapterCore=2.0.43+26.1.2
+versionAdapterCore=2.0.45+26.1.2
 versionAdapterRuntime=1.0.0+26.1.2
 
 versionMc=26.1.2
 versionNeoForge=26.1.2.77
-versionLaunchpad=1.6.2+26.1.2
+versionLaunchpad=1.6.3+26.1.2
 versionAutoRenamingTool=2.0.23
 versionClassTweaker=0.3.0-beta.2
 versionForgifiedFabricLoader=2.5.85+0.19.3+26.1.2

--- a/src/main/java/org/sinytra/connector/locator/ConnectorLocator.java
+++ b/src/main/java/org/sinytra/connector/locator/ConnectorLocator.java
@@ -33,6 +33,7 @@ import org.sinytra.connector.transformer.jar.JarTransformer.TransformableJar;
 import org.sinytra.connector.transformer.jar.JarTransformer.TransformedFabricModPath;
 import org.sinytra.connector.transformer.jar.MetadataReader;
 import org.sinytra.connector.transformer.transform.FabricMetadataTransformer;
+import org.sinytra.connector.util.ConnectorConfig;
 import org.sinytra.connector.util.ConnectorUtil;
 import org.sinytra.launchpad.api.FabricModFactory;
 import org.slf4j.Logger;
@@ -96,10 +97,6 @@ public class ConnectorLocator implements IDependencyLocator {
             .filter(m -> !(m.getModFileInfo() instanceof StubModFileInfo))
             .toList();
 
-        String mcVersion = determineMcVersion(discoveredNeoMods);
-        TransformerEnvironment environment = new ConnectorTransformerEnvironment(mcVersion, findCoremodsLibarary(discoveredNeoMods));
-        JarTransformer transformer = new JarTransformer(environment);
-
         // Get all existing mods
         Collection<SimpleModInfo> loadedModInfos = getPreviouslyDiscoveredMods(discoveredNeoMods);
         Collection<String> loadedModIds = loadedModInfos.stream()
@@ -107,6 +104,11 @@ public class ConnectorLocator implements IDependencyLocator {
             .map(SimpleModInfo::modid)
             .collect(Collectors.toUnmodifiableSet());
         Collection<IModFile> loadedModFiles = loadedModInfos.stream().map(SimpleModInfo::origin).toList();
+
+        String mcVersion = determineMcVersion(discoveredNeoMods);
+        Map<String, String> activeModAliases = getActiveModAliases(loadedModIds);
+        TransformerEnvironment environment = new ConnectorTransformerEnvironment(mcVersion, findCoremodsLibarary(discoveredNeoMods), activeModAliases);
+        JarTransformer transformer = new JarTransformer(environment);
 
         List<IModFile> interest = discoveredMods.stream()
             .filter(m -> m.getModFileInfo() instanceof StubModFileInfo)
@@ -258,6 +260,17 @@ public class ConnectorLocator implements IDependencyLocator {
         // Skip loading mods that already have a native neo equivalent loaded
         String neoModId = FabricMetadataTransformer.normalizeModId(metadata.getId());
         return !loadedNeoMods.contains(neoModId);
+    }
+
+    private static Map<String, String> getActiveModAliases(Collection<String> loadedNeoMods) {
+        Map<String, String> aliases = new HashMap<>();
+        ConnectorConfig.INSTANCE.get().globalModAliases().asMap().forEach((nativeId, fabricIds) -> {
+            String normalizedNativeId = FabricMetadataTransformer.normalizeModId(nativeId);
+            if (loadedNeoMods.contains(normalizedNativeId)) {
+                fabricIds.forEach(fabricId -> aliases.put(fabricId, normalizedNativeId));
+            }
+        });
+        return aliases;
     }
 
     private static IModFile.Type determineModType(FabricModPath path, List<IModFile> discoveredNeoMods) {

--- a/src/main/java/org/sinytra/connector/locator/transform/ConnectorTransformerEnvironment.java
+++ b/src/main/java/org/sinytra/connector/locator/transform/ConnectorTransformerEnvironment.java
@@ -32,6 +32,8 @@ import java.lang.invoke.MethodType;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @SuppressWarnings("UnstableApiUsage")
 public class ConnectorTransformerEnvironment implements TransformerEnvironment {
@@ -42,6 +44,7 @@ public class ConnectorTransformerEnvironment implements TransformerEnvironment {
     private static final MethodHandle BYTECODE_PROVIDER_CTR;
     
     private final String mcVersion;
+    private final Map<String, String> modIdAliases;
     @Nullable
     private final IModFile coremodsFile;
 
@@ -55,9 +58,10 @@ public class ConnectorTransformerEnvironment implements TransformerEnvironment {
         }
     }
 
-    public ConnectorTransformerEnvironment(String mcVersion, @Nullable IModFile coremodsFile) {
+    public ConnectorTransformerEnvironment(String mcVersion, @Nullable IModFile coremodsFile, Map<String, String> modIdAliases) {
         this.mcVersion = mcVersion;
         this.coremodsFile = coremodsFile;
+        this.modIdAliases = Map.copyOf(modIdAliases);
     }
 
     @Override
@@ -137,8 +141,21 @@ public class ConnectorTransformerEnvironment implements TransformerEnvironment {
     }
 
     @Override
+    public Map<String, String> getModIdAliases() {
+        return this.modIdAliases;
+    }
+
+    @Override
     public String getJarCacheVersion() {
-        return ConnectorUtil.getJarCacheVersion();
+        String version = ConnectorUtil.getJarCacheVersion();
+        if (version == null || this.modIdAliases.isEmpty()) {
+            return version;
+        }
+        String aliases = this.modIdAliases.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey())
+            .map(entry -> entry.getKey() + "=" + entry.getValue())
+            .collect(Collectors.joining(","));
+        return version + ",aliases=" + aliases;
     }
 
     private static Path getCacheDir() {

--- a/transformer/build.gradle.kts
+++ b/transformer/build.gradle.kts
@@ -65,12 +65,24 @@ dependencies {
     implementation("net.neoforged.fancymodloader:loader:11.0.13")
     implementation("net.fabricmc:sponge-mixin:0.15.2+mixin.0.8.7")
 
+    testImplementation(platform("org.junit:junit-bom:6.0.3"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
     "runnerImplementation"(sourceSets.main.get().output)
     shade("runnerImplementation"("info.picocli:picocli:4.7.7")!!)
     "runnerAnnotationProcessor"("info.picocli:picocli-codegen:4.7.7")
 }
 
 tasks {
+    test {
+        useJUnitPlatform()
+        systemProperty("java.io.tmpdir", layout.buildDirectory.dir("tmp/tests").get().asFile)
+        doFirst {
+            layout.buildDirectory.dir("tmp/tests").get().asFile.mkdirs()
+        }
+    }
+
     compileJava {
         options.compilerArgs.add("-Aproject=${project.group}/${project.name}")
     }

--- a/transformer/src/main/java/org/sinytra/connector/transformer/TransformerEnvironment.java
+++ b/transformer/src/main/java/org/sinytra/connector/transformer/TransformerEnvironment.java
@@ -10,6 +10,7 @@ import org.sinytra.connector.transformer.transform.TransformProgressMeter;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 public interface TransformerEnvironment {
     Path getAuditReportPath();
@@ -31,6 +32,10 @@ public interface TransformerEnvironment {
     RuntimeException onTransformationError(String msg, Throwable throwable);
 
     int getFabricMixinCompatibility(LoaderModMetadata metadata);
+
+    default Map<String, String> getModIdAliases() {
+        return Map.of();
+    }
 
     String getJarCacheVersion();
 }

--- a/transformer/src/main/java/org/sinytra/connector/transformer/jar/JarTransformInstance.java
+++ b/transformer/src/main/java/org/sinytra/connector/transformer/jar/JarTransformInstance.java
@@ -37,9 +37,11 @@ public class JarTransformInstance {
     private final ClassLookup cleanClassLookup;
     private final AuditTrail auditTrail;
     private final TransformerEnvironment environment;
+    private final FabricMetadataTransformer metadataTransformer;
 
     public JarTransformInstance(TransformerEnvironment environment) {
         this.environment = environment;
+        this.metadataTransformer = new FabricMetadataTransformer(environment.getModIdAliases());
 
         this.cleanClassLookup = environment.getCleanClassLookup();
         this.bfu = new BytecodeFixerUpperFrontend(this.cleanClassLookup, MixinClassLookup.INSTANCE, this.environment);
@@ -55,7 +57,7 @@ public class JarTransformInstance {
         Stopwatch stopwatch = Stopwatch.createStarted();
 
         if (metadata.generated()) {
-            processGeneratedJar(input, output, stopwatch);
+            processGeneratedJar(input, output, stopwatch, this.metadataTransformer);
             return null;
         }
 
@@ -67,10 +69,12 @@ public class JarTransformInstance {
         int fabricLVTCompatibility = this.environment.getFabricMixinCompatibility(metadata.modMetadata());
         PatchEnvironment environment = PatchEnvironment.create(refmapHolder, this.cleanClassLookup, this.bfu.unwrap(), fabricLVTCompatibility, jarTrail);
         MixinPatchTransformer patchTransformer = new MixinPatchTransformer(this.environment, environment, accessorRedirectTransformer.getPatches());
+        FabricEnumExtensionTransformer enumExtensionTransformer = new FabricEnumExtensionTransformer(metadata);
 
         Renamer.Builder builder = Renamer.builder()
             .add(new JarSignatureStripper())
-            .add(FabricMetadataTransformer.INSTANCE)
+            .add(this.metadataTransformer)
+            .add(enumExtensionTransformer)
             .add(new ClassNodeTransformer(
                 new FieldToMethodTransformer(metadata.modMetadata().getClassTweaker()),
                 new ClassAnalysingTransformer()
@@ -85,6 +89,7 @@ public class JarTransformInstance {
             renamer.run(input, output.toFile());
 
             try (FileSystem zipFile = FileSystems.newFileSystem(output)) {
+                enumExtensionTransformer.writeGeneratedResources(zipFile.getPath("/"));
                 patchTransformer.finalize(zipFile.getPath("/"), metadata.mixinConfigs(), refmap.files(), refmapHolder.getDirtyRefmaps());
             }
         } catch (Throwable t) {
@@ -106,14 +111,14 @@ public class JarTransformInstance {
         return jarTrail;
     }
 
-    private static void processGeneratedJar(File input, Path output, Stopwatch stopwatch) throws IOException {
+    private static void processGeneratedJar(File input, Path output, Stopwatch stopwatch, FabricMetadataTransformer metadataTransformer) throws IOException {
         Files.copy(input.toPath(), output);
 
         try (FileSystem fs = FileSystems.newFileSystem(output)) {
             Path path = fs.getPath(TransformerUtil.FABRIC_MOD_JSON);
             byte[] data = Files.readAllBytes(path);
             ResourceEntry entry = ResourceEntry.create(TransformerUtil.FABRIC_MOD_JSON, 0, data);
-            ResourceEntry processed = Objects.requireNonNull(FabricMetadataTransformer.INSTANCE.process(entry), "Failed to process FMJ entry");
+            ResourceEntry processed = Objects.requireNonNull(metadataTransformer.process(entry), "Failed to process FMJ entry");
             Files.write(path, processed.getData());
         } catch (IOException e) {
             throw new UncheckedIOException("Error patching generated jar file", e);

--- a/transformer/src/main/java/org/sinytra/connector/transformer/transform/DebugifyShadowFieldTransformer.java
+++ b/transformer/src/main/java/org/sinytra/connector/transformer/transform/DebugifyShadowFieldTransformer.java
@@ -1,0 +1,52 @@
+package org.sinytra.connector.transformer.transform;
+
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.FieldInsnNode;
+import org.objectweb.asm.tree.FieldNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.sinytra.adapter.env.ann.ClassTarget;
+import org.sinytra.adapter.env.ctx.PatchContext;
+import org.sinytra.adapter.env.ctx.PatchResult;
+import org.sinytra.adapter.transform.ClassTransformer;
+
+final class DebugifyShadowFieldTransformer implements ClassTransformer {
+    static final String MIXIN = "dev/isxander/debugify/mixins/basic/mc121706/RangedBowAttackGoalMixin";
+    static final String OLD_TYPE = "net/minecraft/world/entity/monster/Monster";
+    static final String NEW_TYPE = "net/minecraft/world/entity/Mob";
+
+    @Override
+    public PatchResult apply(ClassNode classNode, ClassTarget classTarget, PatchContext context) {
+        if (!MIXIN.equals(classNode.name)) {
+            return PatchResult.PASS;
+        }
+
+        boolean applied = false;
+        String oldDescriptor = 'L' + OLD_TYPE + ';';
+        String newDescriptor = 'L' + NEW_TYPE + ';';
+        for (FieldNode field : classNode.fields) {
+            if (field.name.equals("mob") && field.desc.equals(oldDescriptor)) {
+                field.desc = newDescriptor;
+                applied = true;
+            }
+        }
+        for (MethodNode method : classNode.methods) {
+            for (AbstractInsnNode instruction : method.instructions) {
+                if (instruction instanceof FieldInsnNode field
+                    && field.owner.equals(classNode.name)
+                    && field.name.equals("mob")
+                    && field.desc.equals(oldDescriptor)) {
+                    field.desc = newDescriptor;
+                    applied = true;
+                } else if (instruction instanceof MethodInsnNode call
+                    && call.owner.equals(OLD_TYPE)
+                    && (call.name.equals("getLookControl") || call.name.equals("getTarget"))) {
+                    call.owner = NEW_TYPE;
+                    applied = true;
+                }
+            }
+        }
+        return applied ? PatchResult.APPLY : PatchResult.PASS;
+    }
+}

--- a/transformer/src/main/java/org/sinytra/connector/transformer/transform/FabricEnumExtensionTransformer.java
+++ b/transformer/src/main/java/org/sinytra/connector/transformer/transform/FabricEnumExtensionTransformer.java
@@ -1,0 +1,130 @@
+package org.sinytra.connector.transformer.transform;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import net.fabricmc.classtweaker.api.ClassTweaker;
+import net.fabricmc.classtweaker.api.ClassTweakerReader;
+import net.fabricmc.classtweaker.api.ClassTweakerWriter;
+import net.fabricmc.classtweaker.visitors.ForwardingVisitor;
+import net.neoforged.art.api.Transformer;
+import org.sinytra.connector.transformer.jar.FabricModFileMetadata;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+
+public final class FabricEnumExtensionTransformer implements Transformer {
+    static final String ENUM_EXTENSIONS_METADATA = "launchpad:enum_extensions";
+    static final String ENUM_EXTENSIONS_PATH = "META-INF/connector_enum_extensions.json";
+
+    private static final String FARMERS_DELIGHT = "farmersdelight";
+    private static final String RECIPE_BOOK_TYPE = "net/minecraft/world/inventory/RecipeBookType";
+    private static final String COOKING_CONSTANT = "FARMERSDELIGHT_COOKING";
+    private static final String RECIPE_BOOK_TYPE_MIXIN = "vectorwing/farmersdelight/common/mixin/refabricated/RecipeBookTypeMixin";
+    private static final String RECIPE_BOOK_TYPE_MIXIN_ENTRY = "refabricated.RecipeBookTypeMixin";
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+
+    private final boolean active;
+    private final String classTweaker;
+    private final Collection<String> mixinConfigs;
+
+    public FabricEnumExtensionTransformer(FabricModFileMetadata metadata) {
+        this(
+            metadata.modMetadata().getId(),
+            metadata.modMetadata().getClassTweaker(),
+            metadata.mixinClasses(),
+            metadata.mixinConfigs()
+        );
+    }
+
+    FabricEnumExtensionTransformer(String modId, String classTweaker, Collection<String> mixinClasses, Collection<String> mixinConfigs) {
+        this.active = FARMERS_DELIGHT.equals(modId) && mixinClasses.contains(RECIPE_BOOK_TYPE_MIXIN);
+        this.classTweaker = classTweaker;
+        this.mixinConfigs = mixinConfigs;
+    }
+
+    @Override
+    public ResourceEntry process(ResourceEntry entry) {
+        if (!this.active) {
+            return entry;
+        }
+        if (entry.getName().equals(TransformerUtil.FABRIC_MOD_JSON)) {
+            return transformMetadata(entry);
+        }
+        if (entry.getName().equals(this.classTweaker)) {
+            return transformClassTweaker(entry);
+        }
+        if (this.mixinConfigs.contains(entry.getName())) {
+            return transformMixinConfig(entry);
+        }
+        return entry;
+    }
+
+    public void writeGeneratedResources(Path root) throws java.io.IOException {
+        if (!this.active) {
+            return;
+        }
+        Path output = root.resolve(ENUM_EXTENSIONS_PATH);
+        Files.createDirectories(output.getParent());
+        Files.writeString(output, GSON.toJson(createEnumExtensions()), StandardCharsets.UTF_8);
+    }
+
+    private static ResourceEntry transformMetadata(ResourceEntry entry) {
+        JsonObject json = parseJson(entry).getAsJsonObject();
+        JsonObject custom = json.has("custom") ? json.getAsJsonObject("custom") : new JsonObject();
+        custom.addProperty(ENUM_EXTENSIONS_METADATA, ENUM_EXTENSIONS_PATH);
+        json.add("custom", custom);
+        return withJson(entry, json);
+    }
+
+    private static ResourceEntry transformClassTweaker(ResourceEntry entry) {
+        ClassTweakerWriter writer = ClassTweakerWriter.create(ClassTweaker.CT_LATEST);
+        ForwardingVisitor filter = new ForwardingVisitor(writer) {
+            @Override
+            public void visitEnumExtension(String owner, String name, boolean transitive) {
+                if (!owner.equals(RECIPE_BOOK_TYPE) || !name.equals(COOKING_CONSTANT)) {
+                    super.visitEnumExtension(owner, name, transitive);
+                }
+            }
+        };
+        ClassTweakerReader.create(filter).read(entry.getData(), "official");
+        return ResourceEntry.create(entry.getName(), entry.getTime(), writer.getOutput());
+    }
+
+    private static ResourceEntry transformMixinConfig(ResourceEntry entry) {
+        JsonObject json = parseJson(entry).getAsJsonObject();
+        JsonArray mixins = json.getAsJsonArray("mixins");
+        if (mixins != null) {
+            mixins.remove(new com.google.gson.JsonPrimitive(RECIPE_BOOK_TYPE_MIXIN_ENTRY));
+        }
+        return withJson(entry, json);
+    }
+
+    private static JsonObject createEnumExtensions() {
+        JsonObject extension = new JsonObject();
+        extension.addProperty("enum", RECIPE_BOOK_TYPE);
+        extension.addProperty("name", COOKING_CONSTANT);
+        extension.addProperty("constructor", "()V");
+        extension.add("parameters", new JsonArray());
+
+        JsonArray entries = new JsonArray();
+        entries.add(extension);
+        JsonObject root = new JsonObject();
+        root.add("entries", entries);
+        return root;
+    }
+
+    private static com.google.gson.JsonElement parseJson(ResourceEntry entry) {
+        return JsonParser.parseReader(new InputStreamReader(new ByteArrayInputStream(entry.getData()), StandardCharsets.UTF_8));
+    }
+
+    private static ResourceEntry withJson(ResourceEntry entry, JsonObject json) {
+        return ResourceEntry.create(entry.getName(), entry.getTime(), GSON.toJson(json).getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/transformer/src/main/java/org/sinytra/connector/transformer/transform/FabricMetadataTransformer.java
+++ b/transformer/src/main/java/org/sinytra/connector/transformer/transform/FabricMetadataTransformer.java
@@ -23,6 +23,8 @@ public class FabricMetadataTransformer implements Transformer {
         .setPrettyPrinting()
         .disableHtmlEscaping()
         .create();
+    private static final List<String> DEPENDENCY_FIELDS = List.of("depends", "recommends", "suggests", "breaks", "conflicts");
+    private final Map<String, String> modIdAliases;
     // Never run entrypoints matching these values
     private static final Collection<String> DISABLED_MIXINEXTRAS_ENTRYPOINTS = Set.of(
         // Mixinextras initializes itself from within its own mixin config plugin.
@@ -32,6 +34,14 @@ public class FabricMetadataTransformer implements Transformer {
         "com.llamalad7.mixinextras.MixinExtrasBootstrap::init"
     );
 
+    public FabricMetadataTransformer() {
+        this(Map.of());
+    }
+
+    public FabricMetadataTransformer(Map<String, String> modIdAliases) {
+        this.modIdAliases = Map.copyOf(modIdAliases);
+    }
+
     @Override
     public ResourceEntry process(ResourceEntry entry) {
         if (entry.getName().equals(TransformerUtil.FABRIC_MOD_JSON)) {
@@ -39,7 +49,7 @@ public class FabricMetadataTransformer implements Transformer {
                 JsonElement raw = JsonParser.parseReader(new InputStreamReader(new ByteArrayInputStream(entry.getData())));
                 JsonObject obj = raw.getAsJsonObject();
 
-                processMetadata(obj);
+                processMetadata(obj, this.modIdAliases);
 
                 byte[] data = GSON.toJson(obj).getBytes(StandardCharsets.UTF_8);
                 return ResourceEntry.create(entry.getName(), entry.getTime(), data);
@@ -54,7 +64,7 @@ public class FabricMetadataTransformer implements Transformer {
         return modId.replace('-', '_');
     }
 
-    private static void processMetadata(JsonObject json) {
+    private static void processMetadata(JsonObject json, Map<String, String> modIdAliases) {
         String modId = json.get("id").getAsString();
         String version = json.get("version").getAsString();
 
@@ -99,10 +109,42 @@ public class FabricMetadataTransformer implements Transformer {
             depends.addProperty(FAPI_MODID, stripped);
         }
 
+        DEPENDENCY_FIELDS.stream()
+            .map(json::getAsJsonObject)
+            .filter(Objects::nonNull)
+            .forEach(dependencies -> applyModIdAliases(dependencies, modIdAliases));
+
         JsonObject custom = Objects.requireNonNullElseGet(json.getAsJsonObject("custom"), JsonObject::new);
         custom.addProperty(TransformerUtil.METADATA_MARKER, true);
         custom.addProperty(TransformerUtil.LAUNCHPAD_MARKER, true);
         json.add("custom", custom);
+    }
+
+    private static void applyModIdAliases(JsonObject dependencies, Map<String, String> modIdAliases) {
+        modIdAliases.forEach((alias, target) -> {
+            JsonElement predicate = dependencies.remove(alias);
+            if (predicate == null) {
+                return;
+            }
+
+            JsonElement existing = dependencies.remove(target);
+            dependencies.add(target, existing == null ? predicate : mergePredicates(existing, predicate));
+        });
+    }
+
+    private static JsonArray mergePredicates(JsonElement first, JsonElement second) {
+        JsonArray merged = new JsonArray();
+        addPredicates(merged, first);
+        addPredicates(merged, second);
+        return merged;
+    }
+
+    private static void addPredicates(JsonArray output, JsonElement predicates) {
+        if (predicates.isJsonArray()) {
+            predicates.getAsJsonArray().forEach(output::add);
+        } else {
+            output.add(predicates);
+        }
     }
 
     private static String stripPatchVersion(String predicate) {

--- a/transformer/src/main/java/org/sinytra/connector/transformer/transform/MixinPatchTransformer.java
+++ b/transformer/src/main/java/org/sinytra/connector/transformer/transform/MixinPatchTransformer.java
@@ -58,6 +58,7 @@ public class MixinPatchTransformer implements Transformer {
             .toList();
         this.patcher = Patcher.builder(this.environment)
             .classTransformers(DynamicPatches.CLASS_PATCHES)
+            .classTransformer(new DebugifyShadowFieldTransformer())
             .methodTransformers(DynamicPatches.methodTransformers(allPatches))
             .build();
     }

--- a/transformer/src/main/java/org/sinytra/connector/transformer/transform/MixinPatches.java
+++ b/transformer/src/main/java/org/sinytra/connector/transformer/transform/MixinPatches.java
@@ -3,9 +3,14 @@ package org.sinytra.connector.transformer.transform;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.FieldInsnNode;
 import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.JumpInsnNode;
+import org.objectweb.asm.tree.LabelNode;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.TypeInsnNode;
+import org.objectweb.asm.tree.VarInsnNode;
 import org.sinytra.adapter.env.ctx.PatchResult;
 import org.sinytra.adapter.env.util.MixinAnnotations;
 import org.sinytra.adapter.transform.patch.MethodPatch;
@@ -75,10 +80,122 @@ public class MixinPatches {
                 .build(),
             MethodPatch.builder()
                 .targetClass("net/minecraft/world/entity/LivingEntity")
-                .targetMethod("goDownInWater()V")
+                .targetMethod("goDownInWater")
+                .targetMixinType(MixinAnnotations.MODIFY_EXPR_VAL)
                 .targetConstant(-0.03999999910593033D)
                 .extractMixin("net/neoforged/neoforge/common/extensions/ILivingEntityExtension")
                 .modifyTarget("sinkInFluid(Lnet/neoforged/neoforge/fluids/FluidType;)V")
+                .build(),
+            MethodPatch.builder()
+                .targetClass("net/minecraft/world/entity/LivingEntity")
+                .targetMethod("travelInAir")
+                .targetMixinType(MixinAnnotations.MODIFY_EXPR_VAL)
+                .targetInjectionPoint("Lnet/minecraft/world/level/block/Block;getFriction()F")
+                .modifyInjectionPoint("Lnet/minecraft/world/level/block/state/BlockState;getFriction(Lnet/minecraft/world/level/LevelReader;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/entity/Entity;)F")
+                .build(),
+            MethodPatch.builder()
+                .targetClass("net/minecraft/world/inventory/AnvilMenu")
+                .targetMethod("createResult")
+                .targetMixinType(MixinAnnotations.MODIFY_CONST)
+                .modifyTarget("createResultInternal")
+                .build(),
+            MethodPatch.builder()
+                .targetClass("net/minecraft/world/item/ItemStack")
+                .targetMethod("forEachModifier(Lnet/minecraft/world/entity/EquipmentSlot;Ljava/util/function/BiConsumer;)V")
+                .targetMixinType(MixinAnnotations.INJECT)
+                .targetInjectionPoint("Lnet/minecraft/world/item/component/ItemAttributeModifiers;forEach(Lnet/minecraft/world/entity/EquipmentSlot;Ljava/util/function/BiConsumer;)V")
+                .disable()
+                .build(),
+            MethodPatch.builder()
+                .targetClass("net/minecraft/server/level/ServerPlayer")
+                .targetMethod("startSleepInBed")
+                .targetMixinType(MixinAnnotations.INJECT)
+                .targetInjectionPoint("Lnet/minecraft/server/level/ServerPlayer;setRespawnPosition(Lnet/minecraft/server/level/ServerPlayer$RespawnConfig;Z)V")
+                .modifyTarget("lambda$startSleepInBed$0(Lnet/minecraft/core/BlockPos;)Lcom/mojang/datafixers/util/Either;")
+                .build(),
+            MethodPatch.builder()
+                .targetClass("net/minecraft/world/item/BoneMealItem")
+                .targetMethod("growCrop")
+                .targetMixinType(MixinAnnotations.INJECT)
+                .targetInjectionPoint("Lnet/minecraft/world/item/ItemStack;shrink(I)V")
+                .modifyTarget("applyBonemeal(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/entity/player/Player;)Z")
+                .build(),
+            MethodPatch.builder()
+                .targetClass("net/minecraft/server/level/ServerPlayerGameMode")
+                .targetMethod("destroyBlock")
+                .targetMixinType(MixinAnnotations.MODIFY_VAR)
+                .targetInjectionPoint("Lnet/minecraft/world/item/ItemStack;mineBlock(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/entity/player/Player;)V")
+                .modifyOrdinal(0)
+                .build(),
+            MethodPatch.builder()
+                .targetClass("net/minecraft/world/level/levelgen/PhantomSpawner")
+                .targetMethod("tick")
+                .targetMixinType(MixinAnnotations.INJECT)
+                .targetInjectionPoint("Lnet/minecraft/world/level/dimension/DimensionType;hasSkyLight()Z")
+                .modifyInjectionPoint("Lnet/minecraft/server/level/ServerPlayer;blockPosition()Lnet/minecraft/core/BlockPos;")
+                .modifyInjectionPointOrdinal(0)
+                .build(),
+            MethodPatch.builder()
+                .targetClass("net/minecraft/world/level/block/FenceGateBlock")
+                .targetMixinType(MixinAnnotations.MODIFY_EXPR_VAL)
+                .targetInjectionPoint("Lnet/minecraft/world/level/block/state/properties/WoodType;fenceGateOpen()Lnet/minecraft/sounds/SoundEvent;")
+                .modifyInjectionPoint("FIELD", "Lnet/minecraft/world/level/block/FenceGateBlock;openSound:Lnet/minecraft/sounds/SoundEvent;")
+                .build(),
+            MethodPatch.builder()
+                .targetClass("net/minecraft/world/level/block/FenceGateBlock")
+                .targetMixinType(MixinAnnotations.MODIFY_EXPR_VAL)
+                .targetInjectionPoint("Lnet/minecraft/world/level/block/state/properties/WoodType;fenceGateClose()Lnet/minecraft/sounds/SoundEvent;")
+                .modifyInjectionPoint("FIELD", "Lnet/minecraft/world/level/block/FenceGateBlock;closeSound:Lnet/minecraft/sounds/SoundEvent;")
+                .build(),
+            MethodPatch.builder()
+                .targetClass("net/minecraft/world/item/component/BlocksAttacks")
+                .targetMethod("hurtBlockingItem")
+                .targetMixinType(MixinAnnotations.WRAP_OPERATION)
+                .targetInjectionPoint("Lnet/minecraft/world/item/ItemStack;hurtAndBreak(ILnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/entity/EquipmentSlot;)V")
+                .disable()
+                .build(),
+            MethodPatch.builder()
+                .targetClass("net/minecraft/world/entity/ai/goal/RangedBowAttackGoal")
+                .targetMethod("tick")
+                .targetMixinType(MixinAnnotations.INJECT)
+                .targetInjectionPoint("Lnet/minecraft/world/entity/monster/Monster;lookAt(Lnet/minecraft/world/entity/Entity;FF)V")
+                .modifyInjectionPoint("Lnet/minecraft/world/entity/Mob;lookAt(Lnet/minecraft/world/entity/Entity;FF)V")
+                .modifyInjectionPointOrdinal(1)
+                .build(),
+            MethodPatch.builder()
+                .targetClass("net/minecraft/world/entity/animal/fox/Fox")
+                .targetMethod("dropAllDeathLoot")
+                .targetMixinType(MixinAnnotations.MODIFY_EXPR_VAL)
+                .targetInjectionPoint("Lnet/minecraft/world/item/ItemStack;isEmpty()Z")
+                .modifyTarget("dropEquipment")
+                .transform((context, configuration) -> {
+                    MethodNode methodNode = context.methodNode();
+                    LabelNode preventDrop = new LabelNode();
+                    methodNode.desc = "(Z)Z";
+                    methodNode.instructions.clear();
+                    methodNode.tryCatchBlocks.clear();
+                    methodNode.localVariables = null;
+                    methodNode.instructions.add(new VarInsnNode(Opcodes.ILOAD, 1));
+                    methodNode.instructions.add(new JumpInsnNode(Opcodes.IFNE, preventDrop));
+                    methodNode.instructions.add(new VarInsnNode(Opcodes.ALOAD, 0));
+                    methodNode.instructions.add(new TypeInsnNode(Opcodes.CHECKCAST, "net/minecraft/world/entity/animal/fox/Fox"));
+                    methodNode.instructions.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, "net/minecraft/world/entity/animal/fox/Fox", "level", "()Lnet/minecraft/world/level/Level;", false));
+                    methodNode.instructions.add(new TypeInsnNode(Opcodes.CHECKCAST, "net/minecraft/server/level/ServerLevel"));
+                    methodNode.instructions.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, "net/minecraft/server/level/ServerLevel", "getGameRules", "()Lnet/minecraft/world/level/gamerules/GameRules;", false));
+                    methodNode.instructions.add(new FieldInsnNode(Opcodes.GETSTATIC, "net/minecraft/world/level/gamerules/GameRules", "MOB_DROPS", "Lnet/minecraft/world/level/gamerules/GameRule;"));
+                    methodNode.instructions.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, "net/minecraft/world/level/gamerules/GameRules", "get", "(Lnet/minecraft/world/level/gamerules/GameRule;)Ljava/lang/Object;", false));
+                    methodNode.instructions.add(new TypeInsnNode(Opcodes.CHECKCAST, "java/lang/Boolean"));
+                    methodNode.instructions.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, "java/lang/Boolean", "booleanValue", "()Z", false));
+                    methodNode.instructions.add(new JumpInsnNode(Opcodes.IFEQ, preventDrop));
+                    methodNode.instructions.add(new InsnNode(Opcodes.ICONST_0));
+                    methodNode.instructions.add(new InsnNode(Opcodes.IRETURN));
+                    methodNode.instructions.add(preventDrop);
+                    methodNode.instructions.add(new InsnNode(Opcodes.ICONST_1));
+                    methodNode.instructions.add(new InsnNode(Opcodes.IRETURN));
+                    methodNode.maxLocals = 2;
+                    methodNode.maxStack = 2;
+                    return PatchResult.APPLY;
+                })
                 .build(),
             // Move redirectors of Map.put to KeyMappingLookup.put
             MethodPatch.builder()

--- a/transformer/src/test/java/org/sinytra/connector/transformer/transform/DebugifyShadowFieldTransformerTest.java
+++ b/transformer/src/test/java/org/sinytra/connector/transformer/transform/DebugifyShadowFieldTransformerTest.java
@@ -1,0 +1,40 @@
+package org.sinytra.connector.transformer.transform;
+
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.FieldInsnNode;
+import org.objectweb.asm.tree.FieldNode;
+import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.sinytra.adapter.env.ctx.PatchResult;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DebugifyShadowFieldTransformerTest {
+    @Test
+    void widensDebugifyRangedBowGoalShadowToMob() {
+        ClassNode node = new ClassNode();
+        node.name = DebugifyShadowFieldTransformer.MIXIN;
+        node.fields.add(new FieldNode(Opcodes.ACC_PRIVATE, "mob", "L" + DebugifyShadowFieldTransformer.OLD_TYPE + ";", null, null));
+        MethodNode method = new MethodNode(Opcodes.ACC_PRIVATE, "lookAtTarget", "()V", null, null);
+        method.instructions.add(new FieldInsnNode(Opcodes.GETFIELD, node.name, "mob", "L" + DebugifyShadowFieldTransformer.OLD_TYPE + ";"));
+        method.instructions.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, DebugifyShadowFieldTransformer.OLD_TYPE, "getTarget", "()Lnet/minecraft/world/entity/LivingEntity;", false));
+        method.instructions.add(new InsnNode(Opcodes.POP));
+        method.instructions.add(new InsnNode(Opcodes.RETURN));
+        node.methods.add(method);
+
+        assertEquals(PatchResult.APPLY, new DebugifyShadowFieldTransformer().apply(node, null, null));
+        assertEquals("L" + DebugifyShadowFieldTransformer.NEW_TYPE + ";", node.fields.getFirst().desc);
+        assertEquals("L" + DebugifyShadowFieldTransformer.NEW_TYPE + ";", ((FieldInsnNode) method.instructions.getFirst()).desc);
+        assertEquals(DebugifyShadowFieldTransformer.NEW_TYPE, ((MethodInsnNode) method.instructions.get(1)).owner);
+    }
+
+    @Test
+    void leavesOtherMixinsUntouched() {
+        ClassNode node = new ClassNode();
+        node.name = "example/OtherMixin";
+        assertEquals(PatchResult.PASS, new DebugifyShadowFieldTransformer().apply(node, null, null));
+    }
+}

--- a/transformer/src/test/java/org/sinytra/connector/transformer/transform/FabricEnumExtensionTransformerTest.java
+++ b/transformer/src/test/java/org/sinytra/connector/transformer/transform/FabricEnumExtensionTransformerTest.java
@@ -1,0 +1,69 @@
+package org.sinytra.connector.transformer.transform;
+
+import com.google.gson.JsonParser;
+import net.neoforged.art.api.Transformer.ResourceEntry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FabricEnumExtensionTransformerTest {
+    private static final String MIXIN_CLASS = "vectorwing/farmersdelight/common/mixin/refabricated/RecipeBookTypeMixin";
+
+    @Test
+    void convertsFarmersDelightRecipeBookType(@TempDir Path tempDir) throws Exception {
+        FabricEnumExtensionTransformer transformer = new FabricEnumExtensionTransformer(
+            "farmersdelight", "farmersdelight.classtweaker", List.of(MIXIN_CLASS), List.of("farmersdelight.mixins.json")
+        );
+
+        ResourceEntry metadata = transformer.process(resource("fabric.mod.json", "{\"id\":\"farmersdelight\"}"));
+        assertEquals(
+            FabricEnumExtensionTransformer.ENUM_EXTENSIONS_PATH,
+            JsonParser.parseString(text(metadata)).getAsJsonObject().getAsJsonObject("custom")
+                .get(FabricEnumExtensionTransformer.ENUM_EXTENSIONS_METADATA).getAsString()
+        );
+
+        ResourceEntry classTweaker = transformer.process(resource("farmersdelight.classtweaker", """
+            classTweaker v2 official
+            transitive-extend-enum net/minecraft/world/inventory/RecipeBookType FARMERSDELIGHT_COOKING
+            transitive-extend-enum net/minecraft/client/gui/screens/recipebook/SearchRecipeBookCategory FARMERSDELIGHT_COOKING
+            """));
+        assertFalse(text(classTweaker).contains("RecipeBookType FARMERSDELIGHT_COOKING"));
+        assertTrue(text(classTweaker).contains("SearchRecipeBookCategory"), text(classTweaker));
+
+        ResourceEntry mixins = transformer.process(resource("farmersdelight.mixins.json", """
+            {"mixins":["OtherMixin","refabricated.RecipeBookTypeMixin"]}
+            """));
+        assertFalse(text(mixins).contains("RecipeBookTypeMixin"));
+        assertTrue(text(mixins).contains("OtherMixin"));
+
+        transformer.writeGeneratedResources(tempDir);
+        String extensions = Files.readString(tempDir.resolve(FabricEnumExtensionTransformer.ENUM_EXTENSIONS_PATH));
+        assertTrue(extensions.contains("FARMERSDELIGHT_COOKING"));
+        assertTrue(extensions.contains("\"constructor\": \"()V\""));
+    }
+
+    @Test
+    void leavesOtherModsUntouched() {
+        FabricEnumExtensionTransformer transformer = new FabricEnumExtensionTransformer(
+            "other", "other.classtweaker", List.of(), List.of()
+        );
+        ResourceEntry input = resource("fabric.mod.json", "{\"id\":\"other\"}");
+        assertEquals(text(input), text(transformer.process(input)));
+    }
+
+    private static ResourceEntry resource(String name, String value) {
+        return ResourceEntry.create(name, 0, value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String text(ResourceEntry entry) {
+        return new String(entry.getData(), StandardCharsets.UTF_8);
+    }
+}

--- a/transformer/src/test/java/org/sinytra/connector/transformer/transform/FabricMetadataTransformerTest.java
+++ b/transformer/src/test/java/org/sinytra/connector/transformer/transform/FabricMetadataTransformerTest.java
@@ -1,0 +1,82 @@
+package org.sinytra.connector.transformer.transform;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import net.neoforged.art.api.Transformer.ResourceEntry;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class FabricMetadataTransformerTest {
+    @Test
+    void rewritesFabricDependencyWhenNativeAliasIsActive() {
+        JsonObject transformed = transform("""
+            {
+              "schemaVersion": 1,
+              "id": "example",
+              "version": "1.0.0",
+              "depends": {
+                "cloth-config2": ">=17"
+              }
+            }
+            """, Map.of("cloth-config2", "cloth_config"));
+
+        JsonObject dependencies = transformed.getAsJsonObject("depends");
+        assertEquals(">=17", dependencies.get("cloth_config").getAsString());
+        assertFalse(dependencies.has("cloth-config2"));
+    }
+
+    @Test
+    void preservesBothPredicatesWhenAliasAndNativeIdsAreDeclared() {
+        JsonObject transformed = transform("""
+            {
+              "schemaVersion": 1,
+              "id": "example",
+              "version": "1.0.0",
+              "depends": {
+                "cloth-config2": ">=17",
+                "cloth_config": "<20"
+              }
+            }
+            """, Map.of("cloth-config2", "cloth_config"));
+
+        JsonArray predicates = transformed.getAsJsonObject("depends").getAsJsonArray("cloth_config");
+        assertEquals(2, predicates.size());
+        assertEquals("<20", predicates.get(0).getAsString());
+        assertEquals(">=17", predicates.get(1).getAsString());
+    }
+
+    @Test
+    void leavesDependencyUntouchedWithoutAnActiveNativeAlias() {
+        JsonObject transformed = transform("""
+            {
+              "schemaVersion": 1,
+              "id": "example",
+              "version": "1.0.0",
+              "depends": {
+                "cloth-config2": "*"
+              }
+            }
+            """, Map.of());
+
+        JsonObject dependencies = transformed.getAsJsonObject("depends");
+        assertEquals("*", dependencies.get("cloth-config2").getAsString());
+        assertFalse(dependencies.has("cloth_config"));
+    }
+
+    private static JsonObject transform(String json, Map<String, String> aliases) {
+        FabricMetadataTransformer transformer = new FabricMetadataTransformer(aliases);
+        ResourceEntry input = ResourceEntry.create(
+            TransformerUtil.FABRIC_MOD_JSON,
+            0,
+            json.getBytes(StandardCharsets.UTF_8)
+        );
+        ResourceEntry output = transformer.process(input);
+        return JsonParser.parseString(new String(output.getData(), StandardCharsets.UTF_8)).getAsJsonObject();
+    }
+}


### PR DESCRIPTION
## The Issue

Several Fabric mods targeting Minecraft 26.1.2 fail during transformation or NeoForge startup because their metadata and mixin targets no longer correspond to the NeoForge runtime.

The failures fall into three categories:

1. Native dependency aliases are applied too late.

   Origins: Legacy depends on the Fabric ID `cloth-config2`, while native NeoForge Cloth Config provides `cloth_config`. Connector's existing alias layer operates after Launchpad has converted the Fabric dependencies into NeoForge metadata, so NeoForge mod sorting rejects the dependency before the alias can take effect.

2. Fabric enum extensions can conflict with NeoForge's extensible-enum mechanism.

   Farmer's Delight Refabricated extends `RecipeBookType` through a Fabric class tweaker and mixin. NeoForge implements this enum as `IExtensibleEnum` and requires additions to be declared through `enumExtensions` metadata instead of direct Mixin extension.

3. Minecraft and NeoForge have moved or replaced several mixin target operations.

   Origins, Farmer's Delight, and Debugify contain injectors targeting methods, fields, calls, constants, or local ordinals that changed in Minecraft 26.1.2 or NeoForge. These failures can be masked by earlier metadata errors, so they become visible only after the preceding problem is repaired.

## The Proposal

This change adds narrowly scoped metadata and mixin adaptations for the affected 26.1.2 artifacts.

### Native dependency aliases

- Determines which configured native mod aliases are active from the NeoForge mods that are actually present.
- Supplies those active aliases to the transformer before Launchpad creates NeoForge metadata.
- Rewrites matching IDs in `depends`, `recommends`, `suggests`, `breaks`, and `conflicts`.
- Preserves and combines version predicates when both the Fabric and native IDs are declared.
- Includes active aliases in the transformed-JAR cache identity.
- Leaves Fabric dependency IDs unchanged when the corresponding native provider is absent.

### Farmer's Delight enum extension

For the exact Farmer's Delight `RecipeBookType` extension, Connector:

- Removes the protected `RecipeBookType` constant from the Fabric class tweaker.
- Leaves the client-only `SearchRecipeBookCategory` enum extension intact.
- Removes only `RecipeBookTypeMixin` from the mixin configuration.
- Generates `META-INF/connector_enum_extensions.json`.
- Adds a `launchpad:enum_extensions` custom metadata property referencing that resource.

The accompanying Launchpad change projects this property into NeoForge's `enumExtensions` mod metadata.

### Mixin adaptations

The explicit 26.1.2 method patches cover:

- Origins' descriptor-less `goDownInWater` selector.
- Block friction moving from `Block` to the NeoForge `BlockState` extension.
- Anvil result logic moving into `createResultInternal`.
- Sleep-position logic moving into the generated `startSleepInBed` lambda.
- Bone-meal consumption moving from `growCrop` to `applyBonemeal`.
- A changed boolean local ordinal in `ServerPlayerGameMode.destroyBlock`.
- Phantom player capture moving to `ServerPlayer.blockPosition`.
- Farmer's Delight fence-gate sounds moving from `WoodType` methods to `FenceGateBlock` fields.
- Debugify's obsolete blocking-item injection where NeoForge already provides equivalent break handling.
- Debugify's ranged-bow goal field widening from `Monster` to `Mob`.
- Debugify's corresponding `lookAt` owner and ordinal change.
- Debugify's fox carried-item drop moving from `dropAllDeathLoot` to `dropEquipment`.

The fox handler is made self-contained by obtaining its `ServerLevel` from the target `Fox` instead of capturing a target-method argument that no longer exists at the new location.

Regression tests cover dependency alias behavior, Farmer's Delight enum conversion, and Debugify's shadow-field adaptation.

## Possible Side Effects

Active dependency aliases now affect transformed metadata before NeoForge mod sorting. This is limited to aliases whose native provider is present. When no matching native mod is loaded, the original Fabric dependency remains untouched.

Changing active aliases also changes the transformation cache identity. This may cause an additional cold transformation when the installed native-mod set changes, but prevents a transformed JAR produced under one alias configuration from being incorrectly reused under another.

When both an alias and its native target are present in the same dependency section, their predicates are combined into an array. This preserves both constraints but may make the generated metadata more restrictive than either predicate alone.

The Farmer's Delight enum conversion is intentionally artifact-specific. It activates only for the `farmersdelight` mod containing the expected `RecipeBookTypeMixin`. Changes to that mod's package names, class tweaker, constant name, or mixin configuration may require this rule to be updated.

The explicit mixin patches match particular target classes, methods, mixin types, constants, and injection points. A different mod using an identical combination could also match a rule, although the signatures are intentionally narrow.

One Debugify injection is disabled because NeoForge's replacement `hurtAndBreak` path already stops item use when the blocking item breaks. If NeoForge changes that behavior later, this equivalence should be reviewed.

## Alternatives

One alternative was to rely on Connector's existing Fabric Loader alias support. This was not sufficient because NeoForge dependency sorting occurs before that alias layer can satisfy Launchpad-generated metadata.

Another option was to require native-mod authors to provide every historical Fabric ID. That would move Connector-specific compatibility requirements into unrelated native mods and would not address existing releases.

Pre-patching the affected mod JARs was also considered. Maintaining separate patched distributions would make updates and provenance harder to manage and would bypass Connector's normal transformation pipeline.

The failing mixins could have been disabled wholesale. This was rejected where the handlers preserve meaningful behavior. Individual injections were disabled only when bytecode inspection showed that they were behavior-neutral or that NeoForge already supplied the same correction.

A generalized automatic conversion of every Fabric enum extension was not selected. Not all Fabric enum targets implement NeoForge's extensible-enum interface, and constructor parameters cannot always be inferred safely. The current conversion therefore handles only the verified Farmer's Delight case.

## Additional Notes

This change depends on the accompanying Adapter and Launchpad changes:

- Adapter branch: `bytecraft/connector-26.1.2-mixin-repairs`
- Launchpad branch: `bytecraft/enum-extension-metadata`

The current dependency pins anticipate:

- Adapter `2.0.45+26.1.2`
- Launchpad `1.6.3+26.1.2`

These version numbers should be adjusted to the actual published versions before merge if the release numbers differ.

Validation completed successfully:

- Connector transformer suite: 7 tests passed.
- Adapter unit suite: 31 tests passed.
- Adapter Minecraft 26.1.2 integration suite: passed.
- Launchpad suite: 12 tests passed.
- Origins: Legacy completed a cold transform, reached the dedicated-server ready marker, and shut down cleanly.
- Farmer's Delight Refabricated completed a cold transform, registered through the NeoForge enum-extension path, reached the ready marker, and shut down cleanly.
- Debugify enabled all 58 selected fixes, reached the ready marker, and shut down cleanly.
- Axiom 5.4.2 with native NeoForge WorldEdit 7.4.3 passed dedicated-server initialization and manual client/editor acceptance.