### PR TITLE
Log path of invalid mod files

### DIFF
--- a/src/main/java/org/sinytra/connector/locator/ConnectorLocator.java
+++ b/src/main/java/org/sinytra/connector/locator/ConnectorLocator.java
@@ -154,7 +154,7 @@ public class ConnectorLocator implements IDependencyLocator {
             .map(out -> {
                 JarContents contents = uncheck(() -> JarContents.ofFilteredPaths(out.paths()));
                 IModFile mf = FabricModFactory.createModFile(contents, attributes, out.type());
-                return Objects.requireNonNull(mf, "Invalid mod file");
+                return Objects.requireNonNull(mf, "Invalid mod file " + contents.getPrimaryPath());
             })
             .toList();
 


### PR DESCRIPTION
## The Issue

Some mods will cause Connector to crash with the error "Invalid mod file" with no further information as to which file is invalid.

## The Proposal

Add the absolute path of the mod file to the error message.

## Possible Side Effects

N/A

## Alternatives

N/A

## Additional Notes

This doesn't help with figuring out *why* a mod file is invalid. I assume such logic would need to be added to Launchpad.
