### PR TITLE
Resolve provided (alias) namespaces when mapping Fabric fluid types

### DIFF
--- a/src/mod/java/org/sinytra/connector/mod/compat/FluidHandlerCompat.java
+++ b/src/mod/java/org/sinytra/connector/mod/compat/FluidHandlerCompat.java
@@ -3,6 +3,7 @@ package org.sinytra.connector.mod.compat;
 import com.mojang.logging.LogUtils;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariantAttributes;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
@@ -47,7 +48,7 @@ public final class FluidHandlerCompat {
             // Allow Forge mods to access Fabric fluid properties
             ResourceKey<Fluid> key = entry.getKey();
             Fluid fluid = entry.getValue();
-            if (ModList.get().getModContainerById(key.location().getNamespace()).map(c -> ConnectorEarlyLoader.isConnectorMod(c.getModId())).orElse(false)) {
+            if (ModList.get().getModContainerById(key.location().getNamespace()).map(c -> ConnectorEarlyLoader.isConnectorMod(c.getModId())).orElseGet(() -> FabricLoader.getInstance().getModContainer(key.location().getNamespace()).map(c -> ConnectorEarlyLoader.isConnectorMod(c.getMetadata().getId())).orElse(false))) {
                 FluidType type = new FabricFluidType(FluidType.Properties.create(), fluid);
                 FABRIC_FLUID_TYPES.put(fluid, type);
                 FABRIC_FLUID_TYPES_BY_NAME.put(key.location(), type);


### PR DESCRIPTION
## The Issue

`FluidHandlerCompat` creates a `FluidType` for a Fabric fluid only if the fluid's registry namespace matches a mod container id in `ModList`. A Fabric mod can register fluids under a namespace it declares via `provides` in `fabric.mod.json` instead of its primary mod id. `ModList` doesn't know such namespaces, so those fluids end up without a `FluidType` and the client crashes on setup:

```
java.lang.RuntimeException: Mod fluids must override getFluidType.
    at net.neoforged.neoforge.common.CommonHooks.getVanillaFluidType(CommonHooks.java:886)
    at net.minecraft.world.level.material.Fluid.getFluidType(Fluid.java:112)
    at net.fabricmc.fabric.impl.client.rendering.fluid.FluidRendererCompat.onClientSetup(FluidRendererCompat.java:35)
```

with `[FluidHandlerCompat]: Missing FluidType for fluid <namespace>:<id>` logged right before it.

This affects any Fabric mod that keeps its fluids in a `provides` namespace, which is common for ports and split-module mods.

## The Proposal

If `ModList` has no container for the namespace, ask `FabricLoader.getInstance().getModContainer(namespace)` instead. The fabric loader resolves provided ids to the owning container, so the existing `isConnectorMod` check can run against the owner's primary mod id. One changed condition and one import.

## Possible Side Effects

Shouldn't be any. The fallback only runs when the namespace is unknown to `ModList`, everything that works today still goes through the unchanged original check. Worst case it adds `FluidType` mappings for fluids that previously had none, which are exactly the cases that crash now.

## Alternatives

Registering fluids under the primary mod id would avoid this, but fluid ids are persisted in worlds, so mods that keep upstream namespaces can't really do that. A mod-side reflection shim that fills `FABRIC_FLUID_TYPES` also works (tested it), but then every affected mod needs Connector-specific code for something the loader can resolve from metadata it already has.

## Additional Notes

No new data or API involved, `provides` is standard Fabric metadata and `getModContainer` already resolves provided ids.