### PR TITLE
Fix accessor redirects, patch priority sorting, and CreativeModeTab coremod descriptor

### DIFF
--- a/src/main/java/org/sinytra/connector/service/coremod/ConnectorClassProcessor.java
+++ b/src/main/java/org/sinytra/connector/service/coremod/ConnectorClassProcessor.java
@@ -71,7 +71,7 @@ public class ConnectorClassProcessor extends SimpleClassProcessor {
                 // searchBarWidth
                 method.visitLdcInsn(89);
                 // tabsImage
-                method.visitFieldInsn(Opcodes.GETSTATIC, "net/minecraft/world/item/CreativeModeTab$Builder", "CREATIVE_INVENTORY_TABS_IMAGE", "Lnet/minecraft/resources/ResourceLocation;"); // tabsImage
+                method.visitFieldInsn(Opcodes.GETSTATIC, "net/minecraft/world/item/CreativeModeTab$Builder", "CREATIVE_INVENTORY_TABS_IMAGE", "Lnet/minecraft/resources/Identifier;"); // tabsImage
                 // labelColor
                 method.visitLdcInsn(4210752);
                 // slotColor
@@ -85,7 +85,7 @@ public class ConnectorClassProcessor extends SimpleClassProcessor {
                 method.visitInsn(Opcodes.DUP);
                 method.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/util/ArrayList", "<init>", "()V", false);
                 // invoke ctr
-                method.visitMethodInsn(Opcodes.INVOKESPECIAL, "net/minecraft/world/item/CreativeModeTab", "<init>", "(Lnet/minecraft/world/item/CreativeModeTab$Row;ILnet/minecraft/world/item/CreativeModeTab$Type;Lnet/minecraft/network/chat/Component;Ljava/util/function/Supplier;Lnet/minecraft/world/item/CreativeModeTab$DisplayItemsGenerator;Lnet/minecraft/resources/ResourceLocation;ZILnet/minecraft/resources/ResourceLocation;IILjava/util/List;Ljava/util/List;)V", false);
+                method.visitMethodInsn(Opcodes.INVOKESPECIAL, "net/minecraft/world/item/CreativeModeTab", "<init>", "(Lnet/minecraft/world/item/CreativeModeTab$Row;ILnet/minecraft/world/item/CreativeModeTab$Type;Lnet/minecraft/network/chat/Component;Ljava/util/function/Supplier;Lnet/minecraft/world/item/CreativeModeTab$DisplayItemsGenerator;Lnet/minecraft/resources/Identifier;ZILnet/minecraft/resources/Identifier;IILjava/util/List;Ljava/util/List;)V", false);
                 method.visitInsn(Opcodes.RETURN);
                 method.visitEnd();
 

--- a/transformer/src/main/java/org/sinytra/connector/transformer/plugin/PatchRegistrarImpl.java
+++ b/transformer/src/main/java/org/sinytra/connector/transformer/plugin/PatchRegistrarImpl.java
@@ -25,7 +25,7 @@ public class PatchRegistrarImpl implements PatchRegistrar {
 
     public List<MethodPatch> getSortedPatches() {
         return this.groups.stream()
-            .sorted(Comparator.comparingInt(Registration::priority))
+            .sorted(Comparator.comparingInt(Registration::priority).reversed())
             .flatMap(r -> r.patches().stream())
             .toList();
     }

--- a/transformer/src/main/java/org/sinytra/connector/transformer/transform/AccessorRedirectTransformer.java
+++ b/transformer/src/main/java/org/sinytra/connector/transformer/transform/AccessorRedirectTransformer.java
@@ -9,19 +9,17 @@ import org.sinytra.adapter.transform.patch.MethodPatch;
 import org.sinytra.connector.transformer.patch.AccessorToInvokerTransformer;
 import org.sinytra.connector.transformer.patch.ClassNodeTransformer;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class AccessorRedirectTransformer implements ClassNodeTransformer.ClassProcessor {
     private static final String PREFIX = "connector$redirect$";
 
     private final List<MethodPatch> patches;
-    private final Map<String, Map<String, String>> methodRenames;
+    private final Map<String, Map<String, String>> methodRenames = new ConcurrentHashMap<>();
 
     public AccessorRedirectTransformer() {
-        Map<String, Map<String, String>> methodRenames = new HashMap<>();
-
         this.patches = FieldToMethodTransformer.REPLACEMENTS.entrySet().stream()
             .flatMap(entry -> entry.getValue().values().stream()
                 .map(s -> MethodPatch.builder()
@@ -34,7 +32,7 @@ public class AccessorRedirectTransformer implements ClassNodeTransformer.ClassPr
 
                         // Add prefix to invoker
                         String newName = PREFIX + methodNode.name;
-                        methodRenames.computeIfAbsent(classNode.name, a -> new HashMap<>())
+                        this.methodRenames.computeIfAbsent(classNode.name, a -> new ConcurrentHashMap<>())
                             .put(methodNode.name + methodNode.desc, newName);
                         methodNode.name = newName;
 
@@ -42,7 +40,6 @@ public class AccessorRedirectTransformer implements ClassNodeTransformer.ClassPr
                     })
                     .build()))
             .toList();
-        this.methodRenames = Map.copyOf(methodRenames);
     }
 
     public List<MethodPatch> getPatches() {


### PR DESCRIPTION
## The Issue

This PR addresses three distinct bugs in the transformer and coremod pipeline:

1. **Broken Accessor Redirects (`AccessorRedirectTransformer`)**: In `AccessorRedirectTransformer`, `this.methodRenames` was assigned an immutable snapshot (`Map.copyOf(methodRenames)`) at construction time before any patches were registered or transformed. Because the transform lambda populated the local map instance after construction, `this.methodRenames` remained empty at all times during class processing. Consequently, call sites for redirected accessors were never renamed to their prefixed names (`connector$redirect$...`), resulting in runtime `NoSuchMethodError` crashes.
2. **Inverted Patch Priority Order (`PatchRegistrarImpl`)**: `PatchRegistrarImpl.getSortedPatches()` sorted patch registrations using natural (ascending) order by priority value (`Comparator.comparingInt(Registration::priority)`). Since `PatchRegistrar` defines `HIGHEST_SYSTEM_PRIORITY = 1000` and `LOWEST_SYSTEM_PRIORITY = -1000`, highest-priority patches (including `BuiltinConnectorPlugin` priority patches) were being applied last instead of first.
3. **Outdated Descriptor in Coremod (`ConnectorClassProcessor`)**: The synthetic `CreativeModeTab` constructor injection in `ConnectorClassProcessor` was still using `Lnet/minecraft/resources/ResourceLocation;` in its `GETSTATIC` instruction and constructor signature descriptor instead of `Lnet/minecraft/resources/Identifier;`, causing `NoSuchFieldError` and `NoSuchMethodError` in 26.1+.

## The Proposal

- **`AccessorRedirectTransformer.java`**: Made `methodRenames` a direct `ConcurrentHashMap` field on the transformer and removed the premature `Map.copyOf` snapshot in the constructor. The transform lambda now populates `this.methodRenames` directly, ensuring method renames persist and are applied during `process(ClassNode)`.
- **`PatchRegistrarImpl.java`**: Inverted the priority comparator in `getSortedPatches()` using `Comparator.comparingInt(Registration::priority).reversed()` so higher integer priorities execute first.
- **`ConnectorClassProcessor.java`**: Replaced all `Lnet/minecraft/resources/ResourceLocation;` descriptors in the `CreativeModeTab` constructor injection with `Lnet/minecraft/resources/Identifier;`.

## Possible Side Effects

- Method patches registered with higher priority values will now correctly execute ahead of lower/default priority patches.
- Accessor redirects will now properly rewrite bytecode instructions in transformed mod classes.
- No public APIs or external behavior's were broken.

## Alternatives

- For `PatchRegistrarImpl`, inverting the integer priority scale was considered, but updating the comparator preserves the existing constants (`HIGHEST_SYSTEM_PRIORITY = 1000`, `LOWEST_SYSTEM_PRIORITY = -1000`) and keeps plugin compatibility intact.
- For `AccessorRedirectTransformer`, passing the rename map through an explicit post-processing step was considered, but keeping a `ConcurrentHashMap` directly on the processor is cleaner and safe for parallel jar transformations.

## Additional Notes

None.